### PR TITLE
Refactor source transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # transmogrifier
+
 Data transformation CLI app for TIMDEX
 
 ## Development
+
 To install with dev dependencies:
+
 ```
 make install
 ```
 
 To run unit tests:
+
 ```
 make test
 ```
 
 To lint the repo:
+
 ```
 make lint
 ```
 
 To run the app:
+
 ```
 pipenv run transform <command>
 ```
@@ -25,5 +31,7 @@ pipenv run transform <command>
 ## Required ENV
 
 `SENTRY_DSN` = If set to a valid Sentry DSN, enables Sentry exception monitoring. This is not needed for local development.
+
+`STATUS_UPDATE_INTERVAL` = The transform process logs the # of records transformed every nth record (1000 by default). Set this env variable to any integer to change the frequency of logging status updates. Can be useful for development/debugging.
 
 `WORKSPACE` = Set to `dev` for local development, this will be set to `stage` and `prod` in those environments by Terraform.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from transmogrifier.cli import main
 
 
-def test_cli_jpal_no_sentry_not_verbose(caplog, monkeypatch, runner, tmp_path):
+def test_transform_no_sentry_not_verbose(caplog, monkeypatch, runner, tmp_path):
     monkeypatch.delenv("SENTRY_DSN", raising=False)
     outfile = tmp_path / "timdex_jpal_records.json"
     result = runner.invoke(
@@ -23,8 +23,9 @@ def test_cli_jpal_no_sentry_not_verbose(caplog, monkeypatch, runner, tmp_path):
     assert "Total time to complete transform" in caplog.text
 
 
-def test_cli_jpal_with_sentry_and_verbose(caplog, monkeypatch, runner, tmp_path):
+def test_transform_with_sentry_and_verbose(caplog, monkeypatch, runner, tmp_path):
     monkeypatch.setenv("SENTRY_DSN", "https://1234567890@00000.ingest.sentry.io/123456")
+    monkeypatch.setenv("STATUS_UPDATE_INTERVAL", "10")
     outfile = tmp_path / "timdex_jpal_records.json"
     result = runner.invoke(
         main,
@@ -45,10 +46,11 @@ def test_cli_jpal_with_sentry_and_verbose(caplog, monkeypatch, runner, tmp_path)
         in caplog.text
     )
     assert "Running transform for source jpal" in caplog.text
+    assert "Status update: 30 records written to output file so far!" in caplog.text
     assert "Completed transform, total record count: 38" in caplog.text
 
 
-def test_cli_no_records(caplog, runner, tmp_path):
+def test_transform_no_records(caplog, runner, tmp_path):
     outfile = tmp_path / "no_records.json"
     result = runner.invoke(
         main,
@@ -63,57 +65,3 @@ def test_cli_no_records(caplog, runner, tmp_path):
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, ValueError)
-
-
-def test_cli_dspace_mets(caplog, runner, tmp_path):
-    outfile = tmp_path / "timdex_dspace_records.json"
-    result = runner.invoke(
-        main,
-        [
-            "-i",
-            "tests/fixtures/dspace/dspace_mets_records.xml",
-            "-o",
-            outfile,
-            "-s",
-            "dspace",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "Completed transform, total record count: 12" in caplog.text
-
-
-def test_cli_whoas(caplog, runner, tmp_path):
-    outfile = tmp_path / "timdex_whoas_records.json"
-    result = runner.invoke(
-        main,
-        [
-            "-i",
-            "tests/fixtures/dspace/dspace_dim_records.xml",
-            "-o",
-            outfile,
-            "-s",
-            "whoas",
-            "-v",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "Running transform for source whoas" in caplog.text
-    assert "Completed transform, total record count: 5" in caplog.text
-
-
-def test_cli_zenodo(caplog, runner, tmp_path):
-    outfile = tmp_path / "timdex_jpal_records.json"
-    result = runner.invoke(
-        main,
-        [
-            "-i",
-            "tests/fixtures/datacite/datacite_records.xml",
-            "-o",
-            outfile,
-            "-s",
-            "zenodo",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "Running transform for source zenodo" in caplog.text
-    assert "Completed transform, total record count: 38" in caplog.text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
 import logging
 
-from transmogrifier.config import configure_logger, configure_sentry
+import pytest
+
+from transmogrifier.config import configure_logger, configure_sentry, get_transformer
+from transmogrifier.sources.datacite import Datacite
 
 
 def test_configure_logger_not_verbose():
@@ -33,3 +36,22 @@ def test_configure_sentry_env_variable_is_dsn(monkeypatch):
     monkeypatch.setenv("SENTRY_DSN", "https://1234567890@00000.ingest.sentry.io/123456")
     result = configure_sentry()
     assert result == "Sentry DSN found, exceptions will be sent to Sentry with env=test"
+
+
+def test_get_transformer_returns_correct_class_name():
+    assert get_transformer("jpal") == Datacite
+
+
+def test_get_transformer_source_missing_class_name_raises_error():
+    with pytest.raises(KeyError):
+        get_transformer("cool-repo")
+
+
+def test_get_transformer_source_wrong_class_name_raises_error(bad_config):
+    with pytest.raises(AttributeError):
+        get_transformer("bad-class-name")
+
+
+def test_get_transformer_source_wrong_module_path_raises_error(bad_config):
+    with pytest.raises(ImportError):
+        get_transformer("bad-module-path")

--- a/tests/test_dspace_dim.py
+++ b/tests/test_dspace_dim.py
@@ -2,27 +2,14 @@ from pytest import raises
 
 import transmogrifier.models as timdex
 from transmogrifier.helpers import parse_xml_records
-from transmogrifier.sources.dspace_dim import DSpaceDim
+from transmogrifier.sources.dspace_dim import DspaceDim
 
 
-def test_dspace_dim_iterates_through_all_records(dspace_dim_records):
-    output_records = DSpaceDim(
-        "whoas",
-        "https://darchive.mblwhoilibrary.org/handle/",
-        "Woods Hole Open Access Server",
-        dspace_dim_records,
+def test_dspace_dim_transform_with_all_fields_transforms_correctly():
+    input_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_dim_record_all_fields.xml"
     )
-    assert len(list(output_records)) == 5
-
-
-def test_dspace_dim_record_all_fields(
-    dspace_dim_record_partial,
-):
-    output_records = dspace_dim_record_partial(
-        input_records=parse_xml_records(
-            "tests/fixtures/dspace/dspace_dim_record_all_fields.xml"
-        )
-    )
+    output_records = DspaceDim("cool-repo", input_records)
     assert next(output_records) == timdex.TimdexRecord(
         citation="Journal of Geophysical Research: Solid Earth 121 (2016): 5859–5879",
         source="A Cool Repository",
@@ -147,14 +134,11 @@ def test_dspace_dim_record_all_fields(
     )
 
 
-def test_dspace_dim_record_optional_fields_blank_transforms_correctly(
-    dspace_dim_record_partial,
-):
-    output_records = dspace_dim_record_partial(
-        input_records=parse_xml_records(
-            "tests/fixtures/dspace/dspace_dim_record_optional_fields_blank.xml"
-        )
+def test_dspace_dim_transform_with_optional_fields_blank_transforms_correctly():
+    input_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_dim_record_optional_fields_blank.xml"
     )
+    output_records = DspaceDim("cool-repo", input_records)
     assert next(output_records) == timdex.TimdexRecord(
         source="A Cool Repository",
         source_link="https://example.com/1912/2641",
@@ -172,14 +156,11 @@ def test_dspace_dim_record_optional_fields_blank_transforms_correctly(
     )
 
 
-def test_dspace_dim_record_optional_fields_missing_transforms_correctly(
-    dspace_dim_record_partial,
-):
-    output_records = dspace_dim_record_partial(
-        input_records=parse_xml_records(
-            "tests/fixtures/dspace/dspace_dim_record_optional_fields_missing.xml"
-        )
+def test_dspace_dim_transform_with_optional_fields_missing_transforms_correctly():
+    input_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_dim_record_optional_fields_missing.xml"
     )
+    output_records = DspaceDim("cool-repo", input_records)
     assert next(output_records) == timdex.TimdexRecord(
         source="A Cool Repository",
         source_link="https://example.com/1912/2641",
@@ -197,37 +178,28 @@ def test_dspace_dim_record_optional_fields_missing_transforms_correctly(
     )
 
 
-def test_dspace_dim_record_title_field_blank_raises_error(
-    dspace_dim_record_partial,
-):
+def test_dspace_dim_transform_with_title_field_blank_raises_error():
+    input_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_dim_record_title_field_blank.xml"
+    )
     with raises(ValueError):
-        output_records = dspace_dim_record_partial(
-            input_records=parse_xml_records(
-                "tests/fixtures/dspace/dspace_dim_record_title_field_blank.xml"
-            )
-        )
+        output_records = DspaceDim("cool-repo", input_records)
         next(output_records)
 
 
-def test_dspace_dim_record_title_field_missing_raises_error(
-    dspace_dim_record_partial,
-):
+def test_dspace_dim_transform_with_title_field_missing_raises_error():
+    input_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_dim_record_title_field_missing.xml"
+    )
     with raises(ValueError):
-        output_records = dspace_dim_record_partial(
-            input_records=parse_xml_records(
-                "tests/fixtures/dspace/dspace_dim_record_title_field_missing.xml"
-            )
-        )
+        output_records = DspaceDim("cool-repo", input_records)
         next(output_records)
 
 
-def test_dspace_dim_record_title_field_multiple_values_raises_error(
-    dspace_dim_record_partial,
-):
+def test_dspace_dim_transform_with_title_field_multiple_values_raises_error():
+    input_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_dim_record_title_field_multiple.xml"
+    )
     with raises(ValueError):
-        output_records = dspace_dim_record_partial(
-            input_records=parse_xml_records(
-                "tests/fixtures/dspace/dspace_dim_record_title_field_multiple.xml"
-            )
-        )
+        output_records = DspaceDim("cool-repo", input_records)
         next(output_records)

--- a/tests/test_dspace_mets.py
+++ b/tests/test_dspace_mets.py
@@ -5,71 +5,38 @@ from transmogrifier.helpers import parse_xml_records
 from transmogrifier.sources.dspace_mets import DspaceMets
 
 
-def test_dspace_mets_iterates_through_all_records():
-    dspace_xml_records = parse_xml_records(
-        "tests/fixtures/dspace/dspace_mets_records.xml"
-    )
-    output_records = DspaceMets(
-        source="dspace",
-        source_base_url="https://dspace.mit.edu/",
-        source_name="DSpace@MIT",
-        input_records=dspace_xml_records,
-    )
-    assert len(list(output_records)) == 12
-
-
-def test_dspace_mets_create_from_xml_with_missing_title_field_raises_error():
+def test_dspace_mets_transform_with_missing_title_field_raises_error():
     dspace_xml_records = parse_xml_records(
         "tests/fixtures/dspace/dspace_mets_record_title_field_missing.xml"
     )
     with pytest.raises(ValueError):
-        output_records = DspaceMets(
-            source="dspace",
-            source_base_url="https://dspace.mit.edu/",
-            source_name="DSpace@MIT",
-            input_records=dspace_xml_records,
-        )
+        output_records = DspaceMets("dspace", dspace_xml_records)
         next(output_records)
 
 
-def test_dspace_mets_create_from_xml_with_blank_title_field_raises_error():
+def test_dspace_mets_transform_with_blank_title_field_raises_error():
     dspace_xml_records = parse_xml_records(
         "tests/fixtures/dspace/dspace_mets_record_title_field_blank.xml"
     )
     with pytest.raises(ValueError):
-        output_records = DspaceMets(
-            source="dspace",
-            source_base_url="https://dspace.mit.edu/",
-            source_name="DSpace@MIT",
-            input_records=dspace_xml_records,
-        )
+        output_records = DspaceMets("dspace", dspace_xml_records)
         next(output_records)
 
 
-def test_dspace_mets_create_from_xml_with_multiple_title_fields_raises_error():
+def test_dspace_mets_transform_with_multiple_title_fields_raises_error():
     dspace_xml_records = parse_xml_records(
         "tests/fixtures/dspace/dspace_mets_record_title_field_multiple.xml"
     )
     with pytest.raises(ValueError):
-        output_records = DspaceMets(
-            source="dspace",
-            source_base_url="https://dspace.mit.edu/",
-            source_name="DSpace@MIT",
-            input_records=dspace_xml_records,
-        )
+        output_records = DspaceMets("dspace", dspace_xml_records)
         next(output_records)
 
 
-def test_dspace_mets_create_from_xml_with_missing_optional_fields_transforms_correctly():
+def test_dspace_mets_transform_with_missing_optional_fields_transforms_correctly():
     dspace_xml_records = parse_xml_records(
         "tests/fixtures/dspace/dspace_mets_record_optional_fields_missing.xml"
     )
-    output_records = DspaceMets(
-        source="dspace",
-        source_base_url="https://dspace.mit.edu/",
-        source_name="DSpace@MIT",
-        input_records=dspace_xml_records,
-    )
+    output_records = DspaceMets("dspace", dspace_xml_records)
     assert next(output_records) == timdex.TimdexRecord(
         source="DSpace@MIT",
         source_link="https://dspace.mit.edu/handle/1721.1/142832",
@@ -83,16 +50,11 @@ def test_dspace_mets_create_from_xml_with_missing_optional_fields_transforms_cor
     )
 
 
-def test_dspace_mets_create_from_xml_with_blank_optional_fields_transforms_correctly():
+def test_dspace_mets_transform_with_blank_optional_fields_transforms_correctly():
     dspace_xml_records = parse_xml_records(
         "tests/fixtures/dspace/dspace_mets_record_optional_fields_blank.xml"
     )
-    output_records = DspaceMets(
-        source="dspace",
-        source_base_url="https://dspace.mit.edu/",
-        source_name="DSpace@MIT",
-        input_records=dspace_xml_records,
-    )
+    output_records = DspaceMets("dspace", dspace_xml_records)
     assert next(output_records) == timdex.TimdexRecord(
         source="DSpace@MIT",
         source_link="https://dspace.mit.edu/handle/1721.1/142832",
@@ -106,16 +68,11 @@ def test_dspace_mets_create_from_xml_with_blank_optional_fields_transforms_corre
     )
 
 
-def test_dspace_mets_create_from_xml_with_all_fields_transforms_correctly():
+def test_dspace_mets_transform_with_all_fields_transforms_correctly():
     dspace_xml_records = parse_xml_records(
         "tests/fixtures/dspace/dspace_mets_record_all_fields.xml"
     )
-    output_records = DspaceMets(
-        source="dspace",
-        source_base_url="https://dspace.mit.edu/",
-        source_name="DSpace@MIT",
-        input_records=dspace_xml_records,
-    )
+    output_records = DspaceMets("dspace", dspace_xml_records)
     assert next(output_records) == timdex.TimdexRecord(
         source="DSpace@MIT",
         source_link="https://dspace.mit.edu/handle/1721.1/142832",

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,14 @@
+from transmogrifier.sources.transformer import Transformer
+
+
+def test_transformer_initializes_with_expected_attributes(datacite_records):
+    transformer = Transformer("cool-repo", datacite_records)
+    assert transformer.source == "cool-repo"
+    assert transformer.source_base_url == "https://example.com/"
+    assert transformer.source_name == "A Cool Repository"
+    assert transformer.input_records == datacite_records
+
+
+def test_transformer_iterates_through_all_records(datacite_records):
+    output_records = Transformer("jpal", datacite_records)
+    assert len(list(output_records)) == 38

--- a/tests/test_zenodo.py
+++ b/tests/test_zenodo.py
@@ -1,13 +1,10 @@
+from transmogrifier.helpers import parse_xml_records
 from transmogrifier.sources.zenodo import Zenodo
 
 
-def test_zenodo_create_source_link(zenodo_record):
-    output_records = Zenodo(
-        "zenodo",
-        "https://zenodo.org/record/",
-        "Zenodo",
-        zenodo_record,
-    )
-    output_record = next(output_records)
-    assert output_record.source_link == "https://zenodo.org/record/4291646"
-    assert output_record.timdex_record_id == "zenodo:4291646"
+def test_zenodo_create_source_record_id_generates_correct_id():
+    input_records = parse_xml_records("tests/fixtures/datacite/zenodo_record.xml")
+    output_records = Zenodo("zenodo", input_records)
+    zenodo_record = next(output_records)
+    assert zenodo_record.source_link == "https://zenodo.org/record/4291646"
+    assert zenodo_record.timdex_record_id == "zenodo:4291646"

--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from typing import Iterator
 
 from attrs import asdict
@@ -98,7 +99,7 @@ def write_timdex_records_to_json(
                 )
             )
             count += 1
-            if count % 1000 == 0:
+            if count % int(os.getenv("STATUS_UPDATE_INTERVAL", 1000)) == 0:
                 logger.info(
                     "Status update: %s records written to output file so far!", count
                 )

--- a/transmogrifier/sources/dspace_mets.py
+++ b/transmogrifier/sources/dspace_mets.py
@@ -1,65 +1,26 @@
 """DSpace METS XML transform module."""
 import logging
-from typing import Iterator
 
 from bs4 import Tag
 
 import transmogrifier.models as timdex
 from transmogrifier.helpers import generate_citation
+from transmogrifier.sources.transformer import Transformer
 
 logger = logging.getLogger(__name__)
 
 
-class DspaceMets:
-    """DSpace METS transform class."""
+class DspaceMets(Transformer):
+    """DSpace METS transformer."""
 
-    def __init__(
-        self,
-        source: str,
-        source_base_url: str,
-        source_name: str,
-        input_records: Iterator[Tag],
-    ) -> None:
+    def transform(self, xml: Tag) -> timdex.TimdexRecord:
         """
-        Initialize DSpaceMets instance.
+        Transform a DSpace METS XML record to a TIMDEX record.
+
+        Overrides the base Transformer.transform() method.
 
         Args:
-            source: Source repository short label.
-            source_base_url: Base URL for source repository records.
-            source_name: Human-Readable full name of the source repository.
-            input_records: Iterator of DSpace METS XML records.
-        """
-        self.source = source
-        self.source_base_url = source_base_url
-        self.source_name = source_name
-        self.input_records = input_records
-
-    def __iter__(self) -> Iterator[timdex.TimdexRecord]:
-        """Iterate over records."""
-        return self
-
-    def __next__(self) -> timdex.TimdexRecord:
-        """Return next transformed record in record iterator."""
-        xml = next(self.input_records)
-        record = self.create_from_dspace_mets_xml(
-            self.source, self.source_base_url, self.source_name, xml
-        )
-        return record
-
-    @classmethod
-    def create_from_dspace_mets_xml(
-        cls, source: str, source_base_url: str, source_name: str, xml: Tag
-    ) -> timdex.TimdexRecord:
-        """
-        Create a TimdexRecord instance from a DSpace METS XML record.
-
-        Args:
-            source: A short label for the source repository.
-            source_base_url: The base URL for the source system from which direct links
-                to source metadata records can be constructed.
-            source_name: The full human-readable name of the source repository to be
-                used in the TIMDEX record.
-            xml: A BeautifulSoup Tag representing a single DSpace record in METS XML.
+            xml: A BeautifulSoup Tag representing a single DSpace METS XML record.
         """
 
         # Required fields in TIMDEX
@@ -77,9 +38,9 @@ class DspaceMets:
                 f"field value of '{main_title[0]}'"
             )
         kwargs = {
-            "source": source_name,
-            "source_link": f"{source_base_url}handle/{source_record_id}",
-            "timdex_record_id": f"{source}:{source_record_id.replace('/', '-')}",
+            "source": self.source_name,
+            "source_link": f"{self.source_base_url}handle/{source_record_id}",
+            "timdex_record_id": f"{self.source}:{source_record_id.replace('/', '-')}",
             "title": main_title[0].string,
         }
 

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -1,0 +1,46 @@
+"""Transformer module."""
+from typing import Iterator
+
+from bs4 import Tag
+
+from transmogrifier.config import SOURCES
+from transmogrifier.models import TimdexRecord
+
+
+class Transformer:
+    """Base transformer class."""
+
+    def __init__(self, source: str, input_records: Iterator[Tag]) -> None:
+        """
+        Initialize Transformer instance.
+
+        Args:
+            source: Source repository short label. Must match a source key from
+                config.SOURCES
+        """
+        self.source = source
+        self.source_base_url = SOURCES[source]["base_url"]
+        self.source_name = SOURCES[source]["name"]
+        self.input_records = input_records
+
+    def __iter__(self) -> Iterator[TimdexRecord]:
+        """Iterate over transformed records."""
+        return self
+
+    def __next__(self) -> TimdexRecord:
+        """Return next transformed record."""
+        xml = next(self.input_records)
+        record = self.transform(xml)
+        return record
+
+    def transform(self, xml: Tag) -> Tag:
+        """
+        Transform an XML record.
+
+        Note: Base Transformer.transform() simply returns the passed XML record. Must be
+        overridden by all subclasses with appropriate transform for the subclass schema.
+
+        Args:
+            xml: A BeautifulSoup Tag representing a single XML record.
+        """
+        return xml

--- a/transmogrifier/sources/zenodo.py
+++ b/transmogrifier/sources/zenodo.py
@@ -1,29 +1,20 @@
-from typing import Iterator
-
 from bs4 import Tag
 
 from transmogrifier.sources.datacite import Datacite
 
 
 class Zenodo(Datacite):
-    def __init__(
-        self,
-        source: str,
-        source_base_url: str,
-        source_name: str,
-        input_records: Iterator[Tag],
-    ):
-        super().__init__(source, source_base_url, source_name, input_records)
+    """Zenodo transformer class."""
 
     @classmethod
     def create_source_record_id(cls, xml: Tag) -> str:
         """
-        Create a source record ID from a Zenodo Datacite XML record. This method
-        is subclassed from the Datacite class as more parsing required for
-        Zenodo identifiers.
+        Create a source record ID from a Zenodo Datacite XML record.
+
+        Overrides the base Datacite.create_source_record_id() method.
+
         Args:
-            xml: A BeautifulSoup Tag representing a single Datacite record in
-            oai_datacite XML.
+            xml: A BeautifulSoup Tag representing a single Datacite XML record.
         """
         source_record_id = xml.header.find("identifier").string.replace(
             "oai:zenodo.org:", ""


### PR DESCRIPTION
#### What does this PR do?
Refactors the source transforms to reduce duplication:
* Adds a base Transformer class with initialization, iteration, and next method that is common to all source transformers.
* Makes source transformers subclasses of the base Transformer and removes their now unnecessary code.
* Moves transformer selection to the config module and determines it at runtime by the static configuration of each source.
* Bases the cli source option on the configured sources to ensure that definition of possible source transforms is located in only one place.
* Adds/updates tests to reflect all changes, including cleaning up fixtures and test names.
* Removes some no-longer-needed tests to reduce duplication.
* Adds an optional env variable to adjust the transform status update interval.

#### How can a reviewer manually see the effects of these changes?
Run any source transform using the test fixtures, e.g.
```
pipenv run transform -i tests/fixtures/datacite/datacite_records.xml -o output/transformed_datacite_records.json -s jpal
```

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/RDI-165

#### Includes new or updated dependencies?
NO

#### Developer
- [ ] All new ENV is documented in README
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes