### PR TITLE
Update subfield logic and tests across sources

### DIFF
--- a/tests/fixtures/datacite/datacite_record_all_fields.xml
+++ b/tests/fixtures/datacite/datacite_record_all_fields.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<record xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <header>
         <identifier>doi:10.7910/DVN/19PPE7</identifier>
         <datestamp>2022-03-26T06:04:55Z</datestamp>
@@ -7,7 +8,8 @@
         <setSpec>IQSS</setSpec>
     </header>
     <metadata>
-        <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+        <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
             <identifier identifierType="DOI">10.7910/DVN/19PPE7</identifier>
             <creators>
                 <creator>
@@ -67,6 +69,7 @@
                 <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1257/app.20150390</relatedIdentifier>
                 <relatedIdentifier relationType="IsVersionOf">10.5281/zenodo.5524464</relatedIdentifier>
                 <relatedIdentifier relatedIdentifierType="ISBN" relationType="IsIdenticalTo">1234567.5524464</relatedIdentifier>
+                <relatedIdentifier relatedIdentifierType="ISBN" relationType="Other">1234567.5524464</relatedIdentifier>
                 <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">https://zenodo.org/communities/astronomy-general</relatedIdentifier>
             </relatedIdentifiers>
             <language>en_US</language>

--- a/tests/fixtures/datacite/datacite_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/datacite/datacite_record_attribute_and_subfield_variations.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+        <identifier>doi:10.7910/DVN/19PPE7</identifier>
+        <datestamp>2022-03-26T06:04:55Z</datestamp>
+        <setSpec>Jameel_Poverty_Action_Lab</setSpec>
+        <setSpec>IQSS</setSpec>
+    </header>
+    <metadata>
+        <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+            <identifier identifierType="">ID-blank-type</identifier>
+            <creators>
+                <creator>
+                    <creatorName></creatorName>
+                </creator>
+                <creator>
+                    <creatorName>Creator, No affiliation no identifier</creatorName>
+                </creator>
+                <creator>
+                    <creatorName>Creator, Blank affiliation blank identifier</creatorName>
+                    <affiliation></affiliation>
+                    <nameIdentifier></nameIdentifier>
+                </creator>
+                <creator>
+                    <creatorName>Creator, Identifier no scheme</creatorName>
+                    <nameIdentifier>0000-0000-0000-0000</nameIdentifier>
+                </creator>
+                <creator>
+                    <creatorName>Creator, Identifier blank scheme</creatorName>
+                    <nameIdentifier nameIdentifierScheme="">0000-0000-0000-0000</nameIdentifier>
+                </creator>
+                <creator>
+                    <creatorName>Creator, No identifier with identifier scheme</creatorName>
+                    <nameIdentifier nameIdentifierScheme="ORCID"></nameIdentifier>
+                </creator>
+            </creators>
+            <titles>
+                <title></title>
+                <title titleType=""></title>
+                <title titleType="">Title with Blank titleType</title>
+                <title titleType="Alternative"></title>
+                <title titleType="">A Second Title with Blank titleType</title>
+            </titles>
+            <subjects>
+                <subject></subject>
+                <subject subjectScheme=""></subject>
+                <subject subjectScheme="">Subject One</subject>
+                <subject subjectScheme="LCSH"></subject>
+            </subjects>
+            <alternateIdentifiers>
+                <alternateIdentifier></alternateIdentifier>
+                <alternateIdentifier>alternate-ID-no-type</alternateIdentifier>
+                <alternateIdentifier alternateIdentifierType="">alternate-ID-blank-type</alternateIdentifier>
+                <alternateIdentifier alternateIdentifierType="Alternate identifier type without string"></alternateIdentifier>
+            </alternateIdentifiers>
+            <contributors>
+                <contributor>
+                    <contributorName></contributorName>
+                </contributor>
+                <contributor>
+                    <contributorName>Contributor, No affiliation no identifier no type</contributorName>
+                </contributor>
+                <contributor type="">
+                    <contributorName>Contributor, Blank affiliation blank identifier blank type</contributorName>
+                    <affiliation></affiliation>
+                    <nameIdentifier></nameIdentifier>
+                </contributor>
+                <contributor>
+                    <contributorName>Contributor, Identifier no scheme</contributorName>
+                    <nameIdentifier>0000-0000-0000-0000</nameIdentifier>
+                </contributor>
+                <contributor>
+                    <contributorName>Contributor, Identifier blank scheme</contributorName>
+                    <nameIdentifier nameIdentifierScheme="">0000-0000-0000-0000</nameIdentifier>
+                </contributor>
+                <contributor>
+                    <contributorName>Contributor, No identifier with identifier scheme</contributorName>
+                    <nameIdentifier nameIdentifierScheme="ORCID"></nameIdentifier>
+                </contributor>
+            </contributors>
+            <dates>
+                <date></date>
+                <date>2020-01-01</date>
+                <date dateInformation=""></date>
+                <date dateInformation="OTHER"></date>
+                <date dateType="">2020-01-02</date>
+            </dates>
+            <resourceType resourceTypeGeneral=""></resourceType>
+            <relatedIdentifiers>
+                <relatedIdentifier></relatedIdentifier>
+                <relatedIdentifier>Related ID no relationType no relatedIdentifierType</relatedIdentifier>
+                <relatedIdentifier relationType="" relatedIdentifierType="">Related ID blank relationType blank relatedIdentifierType</relatedIdentifier>
+                <relatedIdentifier relationType="IsIdenticalTo"></relatedIdentifier>
+                <relatedIdentifier relationType="IsIdenticalTo">Related ID relationType IsIdenticalTo no relationIdentifierType</relatedIdentifier>
+                <relatedIdentifier relationType="IsIdenticalTo" relatedIdentifierType="">Related ID relationType IsIdenticalTo blank relationIdentifierType</relatedIdentifier>
+            </relatedIdentifiers>
+            <sizes>
+                <size></size>
+            </sizes>
+            <formats>
+                <format></format>
+            </formats>
+            <version></version>
+            <rightsList>
+                <rights></rights>
+                <rights>Right no URI</rights>
+                <rights rightsURI=""></rights>
+                <rights rightsURI="">Right blank URI</rights>
+                <rights rightsURI="Right URI without string"></rights>
+            </rightsList>
+            <descriptions>
+                <description></description>
+                <description>Description no type</description>
+                <description descriptionType=""></description>
+                <description descriptionType="">Description blank type</description>
+                <description descriptionType="Other"></description>
+                <description descriptionType="Abstract"></description>
+            </descriptions>
+            <fundingReferences>
+                <fundingReference></fundingReference>
+                <fundingReference>
+                    <funderName></funderName>
+                    <funderIdentifier></funderIdentifier>
+                    <awardNumber></awardNumber>
+                </fundingReference>
+                <fundingReference>
+                    <funderName></funderName>
+                    <funderIdentifier funderIdentifierType=""></funderIdentifier>
+                    <awardNumber awardURI=""></awardNumber>
+                </fundingReference>
+                <fundingReference>
+                    <funderName>Funder name no identifier no award</funderName>
+                </fundingReference>
+                <fundingReference>
+                    <funderName>Funder name blank identifier blank award</funderName>
+                    <funderIdentifier></funderIdentifier>
+                    <awardNumber></awardNumber>
+                </fundingReference>
+                <fundingReference>
+                    <funderIdentifier>Funder identifier no type</funderIdentifier>
+                </fundingReference>
+                <fundingReference>
+                    <funderIdentifier funderIdentifierType="">Funder identifier blank type</funderIdentifier>
+                </fundingReference>
+                <fundingReference>
+                    <funderIdentifier funderIdentifierType="Funder identifier type without string"></funderIdentifier>
+                </fundingReference>
+                <fundingReference>
+                    <awardNumber>Funder award no uri</awardNumber>
+                </fundingReference>
+                <fundingReference>
+                    <awardNumber awardURI="">Funder award blank uri</awardNumber>
+                </fundingReference>
+                <fundingReference>
+                    <awardNumber awardURI="Funder award uri without string"></awardNumber>
+                </fundingReference>
+            </fundingReferences>
+        </resource>
+    </metadata>
+</record>

--- a/tests/fixtures/dspace/dspace_dim_record_attribute_variations.xml
+++ b/tests/fixtures/dspace/dspace_dim_record_attribute_variations.xml
@@ -1,0 +1,33 @@
+<records>
+  <record xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+      <identifier>oai:darchive.mblwhoilibrary.org:1912/2641</identifier>
+      <datestamp>2020-01-28T19:30:01Z</datestamp>
+      <setSpec>com_1912_3</setSpec>
+      <setSpec>col_1912_534</setSpec>
+    </header>
+    <metadata>
+      <dim:dim xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+        xmlns:doc="http://www.lyncode.com/xoai"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
+        <dim:field element="contributor">Contributor, No Qualifier</dim:field>
+        <dim:field element="contributor" qualifier="">Contributor, Blank Qualifier</dim:field>
+        <dim:field element="date" note="Date no qualifier">2020-01-01</dim:field>
+        <dim:field element="date" qualifier="" note="Date blank qualifier">2020-01-02</dim:field>
+        <dim:field element="identifier">Identifier no qualifier</dim:field>
+        <dim:field element="identifier" qualifier="">Identifier blank qualifier</dim:field>
+        <dim:field element="description">Description no qualifier</dim:field>
+        <dim:field element="description" qualifier="">Description blank qualifier</dim:field>
+        <dim:field element="relation">Related item no qualifier</dim:field>
+        <dim:field element="relation" qualifier="">Related item blank qualifier</dim:field>
+        <dim:field element="rights">Right no qualifier</dim:field>
+        <dim:field element="rights" qualifier="">Right blank qualifier</dim:field>
+        <dim:field element="subject">Subject no qualifier</dim:field>
+        <dim:field element="subject" qualifier="">Subject blank qualifier</dim:field>
+        <dim:field element="title" qualitier="">Title with Blank Qualifier</dim:field>
+        <dim:field element="title">Additional Title with No Qualifier</dim:field>
+      </dim:dim>
+    </metadata>
+  </record>
+</records>

--- a/tests/fixtures/dspace/dspace_mets_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/dspace/dspace_mets_record_attribute_and_subfield_variations.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+        <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
+        <datestamp>2022-06-01T03:46:27Z</datestamp>
+        <setSpec>com_1721.1_7582</setSpec>
+        <setSpec>hdl_1721.1_7582</setSpec>
+        <setSpec>com_1721.1_7581</setSpec>
+        <setSpec>hdl_1721.1_7581</setSpec>
+        <setSpec>col_1721.1_131023</setSpec>
+        <setSpec>hdl_1721.1_131023</setSpec>
+    </header>
+    <metadata>
+        <mets xmlns="http://www.loc.gov/METS/"
+            xmlns:doc="http://www.lyncode.com/xoai"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
+            <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
+                <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
+                    <name>mit-6</name>
+                </agent>
+            </metsHdr>
+            <dmdSec ID="DMD_1721.1_142832">
+                <mdWrap MDTYPE="MODS">
+                    <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                        <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                            <mods:name></mods:name>
+                            <mods:name>
+                                <mods:namePart></mods:namePart>
+                            </mods:name>
+                            <mods:name>
+                                <mods:role></mods:role>
+                                <mods:namePart></mods:namePart>
+                            </mods:name>
+                            <mods:name>
+                                <mods:role>
+                                    <mods:roleTerm></mods:roleTerm>
+                                </mods:role>
+                                <mods:namePart></mods:namePart>
+                            </mods:name>
+                            <mods:name>
+                                <mods:role>
+                                    <mods:roleTerm>advisor</mods:roleTerm>
+                                </mods:role>
+                            </mods:name>
+                            <mods:name>
+                                <mods:role>
+                                    <mods:roleTerm>advisor</mods:roleTerm>
+                                </mods:role>
+                                <mods:namePart></mods:namePart>
+                            </mods:name>
+                            <mods:name>
+                                <mods:namePart>One, Author</mods:namePart>
+                            </mods:name>
+                            <mods:name>
+                                <mods:role></mods:role>
+                                <mods:namePart>Two, Author</mods:namePart>
+                            </mods:name>
+                            <mods:name>
+                                <mods:role>
+                                    <mods:roleTerm></mods:roleTerm>
+                                </mods:role>
+                                <mods:namePart>Three, Author</mods:namePart>
+                            </mods:name>
+                            <mods:extension>
+                                <mods:dateAccessioned encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAccessioned>
+                            </mods:extension>
+                            <mods:extension>
+                                <mods:dateAvailable encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAvailable>
+                            </mods:extension>
+                            <mods:originInfo>
+                                <mods:dateIssued encoding="iso8601">2021-09</mods:dateIssued>
+                            </mods:originInfo>
+                            <mods:identifier></mods:identifier>
+                            <mods:identifier>ID-no-type</mods:identifier>
+                            <mods:identifier type=""></mods:identifier>
+                            <mods:identifier type="">ID-blank-type</mods:identifier>
+                            <mods:identifier type="citation"></mods:identifier>
+                            <mods:identifier type="other"></mods:identifier>
+                            <mods:identifier type="uri"></mods:identifier>
+                            <mods:identifier type="uri">https://link-to-item</mods:identifier>
+                            <mods:accessCondition></mods:accessCondition>
+                            <mods:accessCondition>Access condition no type</mods:accessCondition>
+                            <mods:accessCondition type=""></mods:accessCondition>
+                            <mods:accessCondition type="">Access condition blank type</mods:accessCondition>
+                            <mods:titleInfo>
+                                <mods:title></mods:title>
+                            </mods:titleInfo>
+                            <mods:titleInfo>
+                                <mods:title type=""></mods:title>
+                            </mods:titleInfo>
+                            <mods:titleInfo>
+                                <mods:title type="">Title with Blank Type</mods:title>
+                            </mods:titleInfo>
+                            <mods:titleInfo>
+                                <mods:title type="No title"></mods:title>
+                            </mods:titleInfo>
+                            <mods:titleInfo>
+                                <mods:title type="">Second Title with Blank Type</mods:title>
+                            </mods:titleInfo>
+                            <mods:genre>Thesis</mods:genre>
+                            <mods:relatedItem></mods:relatedItem>
+                            <mods:relatedItem>Related item no type</mods:relatedItem>
+                            <mods:relatedItem type=""></mods:relatedItem>
+                            <mods:relatedItem type="">Related item blank type</mods:relatedItem>
+                            <mods:relatedItem type="series"></mods:relatedItem>
+                            <mods:relatedItem type="other"></mods:relatedItem>
+                        </mods:mods>
+                    </xmlData>
+                </mdWrap>
+            </dmdSec>
+            <amdSec ID="FO_1721.1_142832_1">
+                <techMD ID="TECH_O_1721.1_142832_1">
+                    <mdWrap MDTYPE="PREMIS">
+                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                            <premis:premis>
+                                <premis:object>
+                                    <premis:objectIdentifier>
+                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
+                                    </premis:objectIdentifier>
+                                    <premis:objectCategory>File</premis:objectCategory>
+                                    <premis:objectCharacteristics>
+                                        <premis:fixity>
+                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                            <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
+                                        </premis:fixity>
+                                        <premis:size>12351827</premis:size>
+                                        <premis:format>
+                                            <premis:formatDesignation>
+                                                <premis:formatName>application/pdf</premis:formatName>
+                                            </premis:formatDesignation>
+                                        </premis:format>
+                                    </premis:objectCharacteristics>
+                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
+                                </premis:object>
+                            </premis:premis>
+                        </xmlData>
+                    </mdWrap>
+                </techMD>
+            </amdSec>
+            <amdSec ID="FT_1721.1_142832_2">
+                <techMD ID="TECH_T_1721.1_142832_2">
+                    <mdWrap MDTYPE="PREMIS">
+                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                            <premis:premis>
+                                <premis:object>
+                                    <premis:objectIdentifier>
+                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
+                                    </premis:objectIdentifier>
+                                    <premis:objectCategory>File</premis:objectCategory>
+                                    <premis:objectCharacteristics>
+                                        <premis:fixity>
+                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                            <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
+                                        </premis:fixity>
+                                        <premis:size>76618</premis:size>
+                                        <premis:format>
+                                            <premis:formatDesignation>
+                                                <premis:formatName>text/plain</premis:formatName>
+                                            </premis:formatDesignation>
+                                        </premis:format>
+                                    </premis:objectCharacteristics>
+                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
+                                </premis:object>
+                            </premis:premis>
+                        </xmlData>
+                    </mdWrap>
+                </techMD>
+            </amdSec>
+            <fileSec>
+                <fileGrp USE="ORIGINAL">
+                </fileGrp>
+                <fileGrp USE="ORIGINAL">
+                    <file>File no mimetype</file>
+                </fileGrp>
+                <fileGrp USE="ORIGINAL" MIMETYPE="">
+                    <file>File blank mimetype</file>
+                </fileGrp>
+                <fileGrp USE="ORIGINAL">
+                    <file MIMETYPE="application/pdf"></file>
+                </fileGrp>
+                <fileGrp USE="OTHER"></fileGrp>
+            </fileSec>
+            <structMap TYPE="LOGICAL" LABEL="DSpace Object">
+                <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
+                    <div TYPE="DSpace BITSTREAM">
+                        <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                    </div>
+                </div>
+            </structMap>
+        </mets>
+    </metadata>
+</record>

--- a/tests/test_datacite.py
+++ b/tests/test_datacite.py
@@ -127,7 +127,7 @@ def test_datacite_transform_with_all_fields_transforms_correctly(
                 uri="10.5281/zenodo.5524464",
             ),
             RelatedItem(
-                relationship="IsIdenticalTo",
+                relationship="Other",
                 uri="1234567.5524464",
             ),
             RelatedItem(
@@ -237,6 +237,125 @@ def test_datacite_transform_with_optional_fields_missing_transforms_correctly():
             )
         ],
         content_type=["Not specified"],
+    )
+
+
+def test_datacite_with_attribute_and_subfield_variations_transforms_correctly():
+    input_records = parse_xml_records(
+        "tests/fixtures/datacite/datacite_record_attribute_and_subfield_variations.xml"
+    )
+    output_records = Datacite("cool-repo", input_records)
+    assert next(output_records) == TimdexRecord(
+        citation=(
+            "Creator, No affiliation no identifier, Creator, Blank affiliation blank "
+            "identifier, Creator, Identifier no scheme, Creator, Identifier blank "
+            "scheme, Creator, No identifier with identifier scheme. Title with Blank "
+            "titleType. https://example.com/doi:10.7910/DVN/19PPE7"
+        ),
+        source="A Cool Repository",
+        source_link="https://example.com/doi:10.7910/DVN/19PPE7",
+        timdex_record_id="cool-repo:doi:10.7910-DVN-19PPE7",
+        title="Title with Blank titleType",
+        alternate_titles=[AlternateTitle(value="A Second Title with Blank titleType")],
+        content_type=["Not specified"],
+        contributors=[
+            Contributor(value="Creator, No affiliation no identifier", kind="Creator"),
+            Contributor(
+                value="Creator, Blank affiliation blank identifier", kind="Creator"
+            ),
+            Contributor(
+                value="Creator, Identifier no scheme",
+                identifier=["0000-0000-0000-0000"],
+                kind="Creator",
+            ),
+            Contributor(
+                value="Creator, Identifier blank scheme",
+                identifier=["0000-0000-0000-0000"],
+                kind="Creator",
+            ),
+            Contributor(
+                value="Creator, No identifier with identifier scheme",
+                kind="Creator",
+            ),
+            Contributor(
+                value="Contributor, No affiliation no identifier no type",
+                kind="Not specified",
+            ),
+            Contributor(
+                value="Contributor, Blank affiliation blank identifier blank type",
+                kind="Not specified",
+            ),
+            Contributor(
+                value="Contributor, Identifier no scheme",
+                identifier=["0000-0000-0000-0000"],
+                kind="Not specified",
+            ),
+            Contributor(
+                value="Contributor, Identifier blank scheme",
+                identifier=["0000-0000-0000-0000"],
+                kind="Not specified",
+            ),
+            Contributor(
+                value="Contributor, No identifier with identifier scheme",
+                kind="Not specified",
+            ),
+        ],
+        dates=[
+            Date(value="2020-01-01"),
+            Date(note="OTHER"),
+            Date(value="2020-01-02"),
+        ],
+        format="electronic resource",
+        funding_information=[
+            Funder(funder_name="Funder name no identifier no award"),
+            Funder(funder_name="Funder name blank identifier blank award"),
+            Funder(funder_identifier="Funder identifier no type"),
+            Funder(funder_identifier="Funder identifier blank type"),
+            Funder(award_number="Funder award no uri"),
+            Funder(award_number="Funder award blank uri"),
+            Funder(award_uri="Funder award uri without string"),
+        ],
+        identifiers=[
+            Identifier(value="ID-blank-type", kind="Not specified"),
+            Identifier(value="alternate-ID-no-type", kind="Not specified"),
+            Identifier(value="alternate-ID-blank-type", kind="Not specified"),
+            Identifier(
+                value="Related ID relationType IsIdenticalTo no relationIdentifierType",
+                kind="IsIdenticalTo",
+            ),
+            Identifier(
+                value="Related ID relationType IsIdenticalTo blank "
+                "relationIdentifierType",
+                kind="IsIdenticalTo",
+            ),
+        ],
+        links=[
+            Link(
+                url="https://example.com/doi:10.7910/DVN/19PPE7",
+                kind="Digital object URL",
+                text="Digital object URL",
+            )
+        ],
+        notes=[
+            Note(value=["Description no type"]),
+            Note(value=["Description blank type"]),
+        ],
+        related_items=[
+            RelatedItem(
+                relationship="Not specified",
+                uri="Related ID no relationType no relatedIdentifierType",
+            ),
+            RelatedItem(
+                relationship="Not specified",
+                uri="Related ID blank relationType blank relatedIdentifierType",
+            ),
+        ],
+        rights=[
+            Rights(description="Right no URI"),
+            Rights(description="Right blank URI"),
+            Rights(uri="Right URI without string"),
+        ],
+        subjects=[Subject(value=["Subject One"], kind="Subject scheme not provided")],
     )
 
 

--- a/tests/test_dspace_dim.py
+++ b/tests/test_dspace_dim.py
@@ -86,12 +86,11 @@ def test_dspace_dim_transform_with_all_fields_transforms_correctly():
         publication_information=["Woods Hole Oceanographic Institution"],
         related_items=[
             timdex.RelatedItem(
-                description=(
-                    "A low resolution version of this movie was published as supplemental"
-                    " material to: Rieder, C. L. and A. Khodjakov. Mitosis through the "
-                    "microscope: advances in seeing inside live dividing cells. Science "
-                    "300 (2003): 91-96, doi: 10.1126/science.1082177"
-                ),
+                description="A low resolution version of this movie was published as "
+                "supplemental material to: Rieder, C. L. and A. Khodjakov. Mitosis "
+                "through the microscope: advances in seeing inside live dividing "
+                "cells. Science 300 (2003): 91-96, doi: 10.1126/science.1082177",
+                relationship="Not specified",
             ),
             timdex.RelatedItem(
                 description="International Association of Aquatic and Marine Science "
@@ -100,6 +99,7 @@ def test_dspace_dim_transform_with_all_fields_transforms_correctly():
             ),
             timdex.RelatedItem(
                 uri="https://doi.org/10.1002/2016JB013228",
+                relationship="Not specified",
             ),
         ],
         rights=[
@@ -128,6 +128,61 @@ def test_dspace_dim_transform_with_all_fields_transforms_correctly():
                 "beginning at diakinesis through telophase to the near completion of "
                 "cytokinesis following meiosis I."
             )
+        ],
+    )
+
+
+def test_dspace_dim_transform_with_attribute_variations_transforms_correctly():
+    input_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_dim_record_attribute_variations.xml"
+    )
+    output_records = DspaceDim("cool-repo", input_records)
+    assert next(output_records) == timdex.TimdexRecord(
+        citation="Title with Blank Qualifier. https://example.com/1912/2641",
+        source="A Cool Repository",
+        source_link="https://example.com/1912/2641",
+        timdex_record_id="cool-repo:1912-2641",
+        title=("Title with Blank Qualifier"),
+        alternate_titles=[
+            timdex.AlternateTitle(value="Additional Title with No Qualifier")
+        ],
+        content_type=["Not specified"],
+        contributors=[
+            timdex.Contributor(kind="Not specified", value="Contributor, No Qualifier"),
+            timdex.Contributor(
+                kind="Not specified", value="Contributor, Blank Qualifier"
+            ),
+        ],
+        dates=[
+            timdex.Date(value="2020-01-01"),
+            timdex.Date(value="2020-01-02"),
+        ],
+        format="electronic resource",
+        identifiers=[
+            timdex.Identifier(kind="Not specified", value="Identifier no qualifier"),
+            timdex.Identifier(kind="Not specified", value="Identifier blank qualifier"),
+        ],
+        notes=[
+            timdex.Note(value=["Description no qualifier"]),
+            timdex.Note(value=["Description blank qualifier"]),
+        ],
+        related_items=[
+            timdex.RelatedItem(
+                description="Related item no qualifier", relationship="Not specified"
+            ),
+            timdex.RelatedItem(
+                description="Related item blank qualifier", relationship="Not specified"
+            ),
+        ],
+        rights=[
+            timdex.Rights(description="Right no qualifier"),
+            timdex.Rights(description="Right blank qualifier"),
+        ],
+        subjects=[
+            timdex.Subject(
+                value=["Subject no qualifier", "Subject blank qualifier"],
+                kind="Subject scheme not provided",
+            ),
         ],
     )
 

--- a/tests/test_dspace_mets.py
+++ b/tests/test_dspace_mets.py
@@ -35,6 +35,55 @@ def test_dspace_mets_transform_with_blank_optional_fields_transforms_correctly()
     )
 
 
+def test_dspace_mets_with_attribute_and_subfield_variations_transforms_correctly():
+    dspace_xml_records = parse_xml_records(
+        "tests/fixtures/dspace/dspace_mets_record_attribute_and_subfield_variations.xml"
+    )
+    output_records = DspaceMets("dspace", dspace_xml_records)
+    assert next(output_records) == timdex.TimdexRecord(
+        source="DSpace@MIT",
+        source_link="https://dspace.mit.edu/handle/1721.1/142832",
+        timdex_record_id="dspace:1721.1-142832",
+        title="Title with Blank Type",
+        citation="Title with Blank Type. 2021-09. Thesis. "
+        "https://dspace.mit.edu/handle/1721.1/142832",
+        alternate_titles=[timdex.AlternateTitle(value="Second Title with Blank Type")],
+        content_type=["Thesis"],
+        contributors=[
+            timdex.Contributor(value="One, Author", kind="Not specified"),
+            timdex.Contributor(value="Two, Author", kind="Not specified"),
+            timdex.Contributor(value="Three, Author", kind="Not specified"),
+        ],
+        dates=[timdex.Date(kind="Publication date", value="2021-09")],
+        file_formats=["application/pdf"],
+        format="electronic resource",
+        identifiers=[
+            timdex.Identifier(kind="Not specified", value="ID-no-type"),
+            timdex.Identifier(kind="Not specified", value="ID-blank-type"),
+            timdex.Identifier(kind="uri", value="https://link-to-item"),
+        ],
+        links=[
+            timdex.Link(
+                kind="Digital object URL",
+                text="Digital object URL",
+                url="https://link-to-item",
+            )
+        ],
+        related_items=[
+            timdex.RelatedItem(
+                description="Related item no type", relationship="Not specified"
+            ),
+            timdex.RelatedItem(
+                description="Related item blank type", relationship="Not specified"
+            ),
+        ],
+        rights=[
+            timdex.Rights(description="Access condition no type"),
+            timdex.Rights(description="Access condition blank type"),
+        ],
+    )
+
+
 def test_dspace_mets_transform_with_all_fields_transforms_correctly():
     dspace_xml_records = parse_xml_records(
         "tests/fixtures/dspace/dspace_mets_record_all_fields.xml"
@@ -56,22 +105,13 @@ def test_dspace_mets_transform_with_all_fields_transforms_correctly():
         "Institute of Technology © 2022.",
         content_type=["Thesis"],
         contributors=[
-            timdex.Contributor(
-                value="Checkelsky, Joseph",
-                kind="advisor",
-            ),
-            timdex.Contributor(
-                value="Tatsumi, Yuki",
-                kind="author",
-            ),
+            timdex.Contributor(value="Checkelsky, Joseph", kind="advisor"),
+            timdex.Contributor(value="Tatsumi, Yuki", kind="author"),
             timdex.Contributor(
                 value="Massachusetts Institute of Technology. Department of Physics",
                 kind="department",
             ),
-            timdex.Contributor(
-                value="Smith, Susie Q.",
-                kind="Contributor role not specified",
-            ),
+            timdex.Contributor(value="Smith, Susie Q.", kind="Not specified"),
         ],
         dates=[timdex.Date(kind="Publication date", value="2021-09")],
         file_formats=["application/pdf"],


### PR DESCRIPTION
#### What does this PR do?

Adds tests and updates source transform logic to ensure all expected variations of source XML subelements and attributes are handled.

#### How can a reviewer manually see the effects of these changes?
To verify that it works on records that previously threw an error, run the transform locally against the latest Zenodo "full" harvest on stage (must be logged into stage with the MITDevelopersLimited role), e.g.:
```
pipenv run transform -i s3://timdex-extract-stage-840055183494/zenodo-full-harvested-records-2022-07-20.xml -o output/zenodo-transformed-records.json -s zenodo
```

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/RDI-233

#### Includes new or updated dependencies?
NO

#### Developer
- **NA** All new ENV is documented in README
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes