### PR TITLE
Update WHOAS and Zenodo content type filters

### DIFF
--- a/tests/fixtures/dspace/dspace_dim_record_all_fields.xml
+++ b/tests/fixtures/dspace/dspace_dim_record_all_fields.xml
@@ -1,5 +1,6 @@
 <records>
-  <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <record xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <header>
       <identifier>oai:darchive.mblwhoilibrary.org:1912/2641</identifier>
       <datestamp>2020-01-28T19:30:01Z</datestamp>
@@ -7,7 +8,9 @@
       <setSpec>col_1912_534</setSpec>
     </header>
     <metadata>
-      <dim:dim xmlns:dim="http://www.dspace.org/xmlns/dspace/dim" xmlns:doc="http://www.lyncode.com/xoai" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
+      <dim:dim xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+        xmlns:doc="http://www.lyncode.com/xoai"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
         <dim:field mdschema="dc" element="contributor" qualifier="author" authority="0a81af48-388e-49c4-936a-547560e4ad1c" confidence="600">LaFountain, James R.</dim:field>
         <dim:field mdschema="dc" element="contributor" qualifier="author" authority="0a81af48-388e-49c4-936a-547560e4ad1c" confidence="600">Oldenbourg, Rudolf</dim:field>
         <dim:field mdschema="dc" element="coverage" qualifier="spatial">Central equatorial Pacific Ocean</dim:field>
@@ -54,6 +57,7 @@ Movie01_LaFountainOldenbourg_MeiosisI_MPEG4.mov: 31105110 bytes, checksum: 5b08f
         <dim:field mdschema="dc" element="title" lang="en">Time lapse movie of meiosis I in a living spermatocyte from the crane fly, Nephrotoma suturalis, viewed with polarized light microscopy</dim:field>
         <dim:field mdschema="dc" element="title" qualifier="alternative" lang="en">An Alternative Title</dim:field>
         <dim:field mdschema="dc" element="type" lang="en">Moving Image</dim:field>
+        <dim:field mdschema="dc" element="type" lang="en">Dataset</dim:field>
       </dim:dim>
     </metadata>
   </record>

--- a/tests/fixtures/dspace/whoas_records_with_valid_and_invalid_content_types.xml
+++ b/tests/fixtures/dspace/whoas_records_with_valid_and_invalid_content_types.xml
@@ -11,6 +11,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
         <dim:field mdschema="dc" element="type" lang="en">Book</dim:field>
         <dim:field mdschema="dc" element="type" lang="en">Book chapter</dim:field>
+        <dim:field mdschema="dc" element="type" lang="en">Text</dim:field>
       </dim:dim>
     </metadata>
   </record>
@@ -32,7 +33,7 @@
   <record xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <header>
-      <identifier>oai:darchive.mblwhoilibrary.org:valid_content_type</identifier>
+      <identifier>oai:darchive.mblwhoilibrary.org:valid_content_types</identifier>
       <datestamp>2020-01-28T19:30:01Z</datestamp>
       <setSpec>com_1912_3</setSpec>
       <setSpec>col_1912_534</setSpec>
@@ -42,6 +43,22 @@
         xmlns:doc="http://www.lyncode.com/xoai"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
         <dim:field mdschema="dc" element="type" lang="en">Moving Image</dim:field>
+        <dim:field mdschema="dc" element="type" lang="en">Dataset</dim:field>
+      </dim:dim>
+    </metadata>
+  </record>
+  <record xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+      <identifier>oai:darchive.mblwhoilibrary.org:no_content_type</identifier>
+      <datestamp>2020-01-28T19:30:01Z</datestamp>
+      <setSpec>com_1912_3</setSpec>
+      <setSpec>col_1912_534</setSpec>
+    </header>
+    <metadata>
+      <dim:dim xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+        xmlns:doc="http://www.lyncode.com/xoai"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dspace.org/xmlns/dspace/dim http://www.dspace.org/schema/dim.xsd">
       </dim:dim>
     </metadata>
   </record>

--- a/tests/test_dspace_dim.py
+++ b/tests/test_dspace_dim.py
@@ -20,7 +20,7 @@ def test_dspace_dim_transform_with_all_fields_transforms_correctly():
         alternate_titles=[
             timdex.AlternateTitle(value="An Alternative Title", kind="alternative"),
         ],
-        content_type=["Moving Image"],
+        content_type=["Moving Image", "Dataset"],
         contents=["Chapter 1"],
         contributors=[
             timdex.Contributor(

--- a/tests/test_whoas.py
+++ b/tests/test_whoas.py
@@ -3,26 +3,40 @@ from transmogrifier.sources.whoas import Whoas
 
 
 def test_valid_content_types_with_all_invalid():
-    content_types = ["Book", "Thesis"]
+    content_types = [
+        "Article",
+        "authority list",
+        "book",
+        "book chapter",
+        "course",
+        "no content type in source record",
+        "other",
+        "preprint",
+        "presentation",
+        "Technical report",
+        "thesis",
+        "text",
+        "working paper",
+    ]
     assert Whoas.valid_content_types(content_types) is False
 
 
 def test_valid_content_types_with_some_invalid():
-    content_types = ["Preprint", "Dataset"]
+    content_types = ["Preprint", "dataset"]
     assert Whoas.valid_content_types(content_types) is True
 
 
 def test_valid_content_types_with_all_valid():
-    content_types = ["Dataset", "Image"]
+    content_types = ["Dataset", "image"]
     assert Whoas.valid_content_types(content_types) is True
 
 
-def test_whoas_skips_records_with_only_invalid_content_types():
+def test_whoas_skips_records_with_only_invalid_or_not_present_content_types():
     input_records = list(
         parse_xml_records(
             "tests/fixtures/dspace/whoas_records_with_valid_and_invalid_content_types.xml"
         )
     )
-    assert len(input_records) == 3
+    assert len(input_records) == 4
     output_records = Whoas("whoas", iter(input_records))
     assert len(list(output_records)) == 2

--- a/tests/test_zenodo.py
+++ b/tests/test_zenodo.py
@@ -11,7 +11,7 @@ def test_zenodo_create_source_record_id_generates_correct_id():
 
 
 def test_valid_content_types_with_all_invalid():
-    content_types = ["lesson", "poster"]
+    content_types = ["journalarticle", "poster"]
     assert Zenodo.valid_content_types(content_types) is False
 
 
@@ -21,7 +21,20 @@ def test_valid_content_types_with_some_invalid():
 
 
 def test_valid_content_types_with_all_valid():
-    content_types = ["dataset", "image"]
+    content_types = [
+        "dataset",
+        "diagram",
+        "drawing",
+        "figure",
+        "image",
+        "other",
+        "photo",
+        "physicalobject",
+        "plot",
+        "software",
+        "taxonomictreatment",
+        "video",
+    ]
     assert Zenodo.valid_content_types(content_types) is True
 
 

--- a/transmogrifier/sources/dspace_dim.py
+++ b/transmogrifier/sources/dspace_dim.py
@@ -47,11 +47,9 @@ class DspaceDim(Transformer):
         fields["citation"] = citation.string if citation and citation.string else None
 
         # content_type
-        if content_type_list := [
-            t.string for t in xml.find_all("dim:field", element="type") if t.string
-        ]:
-            if self.valid_content_types(content_type_list):
-                fields["content_type"] = content_type_list
+        if content_types := self.get_content_types(xml):
+            if self.valid_content_types(content_types):
+                fields["content_type"] = content_types
             else:
                 return None
 
@@ -250,6 +248,21 @@ class DspaceDim(Transformer):
             fields.setdefault("summary", []).append(description.string)
 
         return fields
+
+    @classmethod
+    def get_content_types(cls, xml: Tag) -> Optional[list[str]]:
+        """
+        Retrieve content types from a DSpace DIM XML record.
+
+        May be overridden by source subclasses that retrieve content type values
+        differently.
+
+        Args:
+            xml: A BeautifulSoup Tag representing a single DSpace DIM XML record.
+        """
+        return [
+            t.string for t in xml.find_all("dim:field", element="type", string=True)
+        ] or None
 
     @classmethod
     def get_main_titles(cls, xml: Tag) -> list[Tag]:

--- a/transmogrifier/sources/whoas.py
+++ b/transmogrifier/sources/whoas.py
@@ -1,21 +1,40 @@
+from bs4 import Tag
+
 from transmogrifier.sources.dspace_dim import DspaceDim
 
 INVALID_CONTENT_TYPES = [
-    "Article",
-    "Authority List",
-    "Book",
-    "Book chapter",
-    "Course",
-    "Preprint",
-    "Presentation",
-    "Technical Report",
-    "Thesis",
-    "Working Paper",
+    "article",
+    "authority list",
+    "book",
+    "book chapter",
+    "course",
+    "no content type in source record",
+    "other",
+    "preprint",
+    "presentation",
+    "technical report",
+    "thesis",
+    "text",
+    "working paper",
 ]
 
 
 class Whoas(DspaceDim):
     """Whoas transformer class."""
+
+    @classmethod
+    def get_content_types(cls, xml: Tag) -> list[str]:
+        """
+        Retrieve content types from a DSpace DIM XML record.
+
+        Overrides the base DspaceDim.get_content_types() method.
+
+        Args:
+            xml: A BeautifulSoup Tag representing a single DSpace DIM XML record.
+        """
+        return [
+            t.string for t in xml.find_all("dim:field", element="type", string=True)
+        ] or ["no content type in source record"]
 
     @classmethod
     def valid_content_types(cls, content_type_list: list[str]) -> bool:
@@ -27,7 +46,7 @@ class Whoas(DspaceDim):
         Args:
             content_type_list: A list of content_type values.
         """
-        if all(item in INVALID_CONTENT_TYPES for item in content_type_list):
+        if all(item.lower() in INVALID_CONTENT_TYPES for item in content_type_list):
             return False
         else:
             return True

--- a/transmogrifier/sources/zenodo.py
+++ b/transmogrifier/sources/zenodo.py
@@ -4,7 +4,20 @@ from bs4 import Tag
 
 from transmogrifier.sources.datacite import Datacite
 
-INVALID_CONTENT_TYPES = ["lesson", "poster", "presentation", "publication"]
+VALID_CONTENT_TYPES = [
+    "dataset",
+    "diagram",
+    "drawing",
+    "figure",
+    "image",
+    "other",
+    "photo",
+    "physicalobject",
+    "plot",
+    "software",
+    "taxonomictreatment",
+    "video",
+]
 
 
 class Zenodo(Datacite):
@@ -33,7 +46,7 @@ class Zenodo(Datacite):
         Args:
             content_type_list: A list of content_type values.
         """
-        if all(item in INVALID_CONTENT_TYPES for item in content_type_list):
-            return False
-        else:
+        if any(item.lower() in VALID_CONTENT_TYPES for item in content_type_list):
             return True
+        else:
+            return False


### PR DESCRIPTION
#### What does this PR do?

Updates the WHOAS and Zenodo content type filters based on stakeholder feedback.

#### How can a reviewer manually see the effects of these changes?
I've re-ingested the WHOAS and Zenodo records from the dev deployment of this code in AWS, so you can verify by going to the [RDI UI](https://rdi.libraries.mit.edu/) and confirming that:
- There are no longer any WHOAS records with "Not specified", "Other", or "Text" content types _unless_ the record also has a content type we do ingest, such as dataset, image, etc.
- Only records with any of the following content types are present in Zenodo records _unless_ the record also has a content type we do ingest (one of these): dataset, image, other, physicalobject, software, video, taxonomictreatment, diagram, drawing, figure, photo, plot

#### Includes new or updated dependencies?
NO

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/RDI-243
- https://mitlibraries.atlassian.net/browse/RDI-246

#### Developer
- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes