### PR TITLE
TIMX-64-expand-get-optional-fields

### DIFF
--- a/config/aspace_type_crosswalk.json
+++ b/config/aspace_type_crosswalk.json
@@ -1,7 +1,7 @@
 {
     "aat": "Art & Architecture Thesaurus",
     "accessrestrict": "Conditions Governing Access",
-    "altformavail": "Alternative Form Available",
+    "altformavail": "Alternate Format",
     "acqinfo": "Acquisition Information",
     "appraisal": "Appraisal",
     "bibliography": "Bibliography",
@@ -14,7 +14,6 @@
     "naf": "Library of Congress Name Authority File",
     "otherfindaid": "Other Finding Aid",
     "processinfo": "Processing Information",
-    "relatedmaterial": "Related Material",
     "relation": "Relation",
     "separatedmaterial": "Separated Material",
     "scopecontent": "Scope and Contents Note",

--- a/tests/fixtures/ead/ead_record_all_fields.xml
+++ b/tests/fixtures/ead/ead_record_all_fields.xml
@@ -68,6 +68,10 @@
                             <extent>4.5 Cubic Feet</extent>
                             <extent>(10 manuscript boxes, 1 legal manuscript box, 1 cassette box)</extent>
                         </physdesc>
+                        <physdesc>
+                            <extent>1.5 Cubic Feet</extent>
+                            <extent>(2 manuscript boxes)</extent>
+                        </physdesc>
                     </did>
                     <altformavail>
                         <head>Location of Copies</head>

--- a/tests/fixtures/ead/ead_record_all_fields.xml
+++ b/tests/fixtures/ead/ead_record_all_fields.xml
@@ -65,7 +65,8 @@
                             <persname authfilenumber="nr99025435" source="viaf">Name 5</persname>
                         </origination>
                         <physdesc>
-                            <extent>31 box(es)</extent>
+                            <extent>4.5 Cubic Feet</extent>
+                            <extent>(10 manuscript boxes, 1 legal manuscript box, 1 cassette box)</extent>
                         </physdesc>
                     </did>
                     <altformavail>
@@ -105,14 +106,44 @@
                         </genreform>
                         <geogname>Boston, MA</geogname>
                     </controlaccess>
-                    <otherfindaid>
-                        <head>Other Finding Aids</head>
-                        <p>A more detailed collection inventory is available to staff in the MIT ArchivesSpace staff interface.</p>
-                    </otherfindaid>
                     <prefercite>
                         <head>Preferred Citation</head>
                         <p>Charles J. Connick Stained Glass Foundation Collection, VC-0002, box X. Massachusetts Institute of Technology, Department of Distinctive Collections, Cambridge, Massachusetts.</p>
                     </prefercite>
+                    <relatedmaterial>
+                        <head>Related Materials</head>
+                        <list>
+                            <head>Collections at the Institute Archives and Special Collections, Massachusetts Institute of Technology</head>
+                            <defitem>
+                                <label>MC-0423</label>
+                                <item>James R. Killian Papers</item>
+                            </defitem>
+                            <defitem>
+                                <label>MC-0416</label>
+                                <item>Karl T. Compton Papers</item>
+                            </defitem>
+                            <defitem>
+                                <label>MC-0029</label>
+                                <item>Carroll Wilson Papers</item>
+                            </defitem>
+                            <defitem>
+                                <label>MC-0060</label>
+                                <item>George Russell Harrison Papers</item>
+                            </defitem>
+                            <defitem>
+                                <label>MC-0351</label>
+                                <item>Margaret Compton Papers</item>
+                            </defitem>
+                            <defitem>
+                                <label>AC-0132</label>
+                                <item>Office of the Chancellor; Records of Provost Julius A. Stratton, Vice President and Provost Julius A. Stratton, and Chancellor Julius A. Stratton</item>
+                            </defitem>
+                            <defitem>
+                                <label>AC-0333</label>
+                                <item>Office of the Vice President, Records of Vannevar Bush</item>
+                            </defitem>
+                        </list>
+                    </relatedmaterial>
                     <relatedmaterial>
                         <head>Related Materials</head>
                         <p>The Charles J. Connick and Associates Archives are located at the Boston Public Library's Fine Arts Department (http://www.bpl.org/research/finearts.htm).</p>

--- a/tests/fixtures/ead/ead_record_all_fields.xml
+++ b/tests/fixtures/ead/ead_record_all_fields.xml
@@ -12,6 +12,13 @@
                 </eadheader>
                 <archdesc level="collection">
                     <did>
+                        <repository>
+                            <corpname>
+                                Massachusetts
+                                <emph>Institute</emph>
+                                of Technology. Libraries. Department of Distinctive Collections
+                            </corpname>
+                        </repository>
                         <unittitle>
                             Charles J. Connick Stained Glass
                             <emph>
@@ -57,7 +64,14 @@
                         <origination>
                             <persname authfilenumber="nr99025435" source="viaf">Name 5</persname>
                         </origination>
+                        <physdesc>
+                            <extent>31 box(es)</extent>
+                        </physdesc>
                     </did>
+                    <altformavail>
+                        <head>Location of Copies</head>
+                        <p>A use copy of photographic plates in box 4 can be found in the Institute Archives and Special Collections reading room.</p>
+                    </altformavail>
                     <arrangement>
                         <head>Arrangement</head>
                         <p>This collection is organized into ten series: </p>
@@ -91,10 +105,20 @@
                         </genreform>
                         <geogname>Boston, MA</geogname>
                     </controlaccess>
+                    <otherfindaid>
+                        <head>Other Finding Aids</head>
+                        <p>A more detailed collection inventory is available to staff in the MIT ArchivesSpace staff interface.</p>
+                    </otherfindaid>
                     <prefercite>
                         <head>Preferred Citation</head>
                         <p>Charles J. Connick Stained Glass Foundation Collection, VC-0002, box X. Massachusetts Institute of Technology, Department of Distinctive Collections, Cambridge, Massachusetts.</p>
                     </prefercite>
+                    <relatedmaterial>
+                        <head>Related Materials</head>
+                        <p>The Charles J. Connick and Associates Archives are located at the Boston Public Library's Fine Arts Department (http://www.bpl.org/research/finearts.htm).</p>
+                        <p>The Charles J. Connick papers, 1901-1949 are located at the Smithsonian Archives of American Art (http://www.aaa.si.edu/collections/charles-j-connick-papers-7235).</p>
+                        <p>Information on the Charles J. Connick Stained Glass Foundation may be found at their website (http://www.cjconnick.org/).</p>
+                    </relatedmaterial>
                     <scopecontent>
                         <head>Scope and Contents</head>
                         <p>
@@ -104,6 +128,10 @@
                         </p>
                         <p>The primary reference material is the job information.  In particular, the job files (boxes 7-9) are used most often in research.  Job files list specific information for each job performed by the studio.  </p>
                     </scopecontent>
+                    <separatedmaterial>
+                        <head>Separated Materials</head>
+                        <p>Issues of Twilight Zine were separated for library cataloging.</p>
+                    </separatedmaterial>
                 </archdesc>
             </ead>
         </metadata>

--- a/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
@@ -202,30 +202,16 @@
                             <emph>Data enclosed in subelement</emph>
                         </geogname>
                     </controlaccess>
-                    <otherfindaid>
-                        <head></head>
-                        <p></p>
-                    </otherfindaid>
-                    <otherfindaid>
-                        <head>Head tag but no other data</head>
-                    </otherfindaid>
-                    <otherfindaid>
-                        <head></head>
-                        <p>Data with blank head tag</p>
-                    </otherfindaid>
-                    <otherfindaid>
-                        <p>Data with no head tag</p>
-                    </otherfindaid>
                     <prefercite>
                         <head></head>
                         <p></p>
                     </prefercite>
                     <relatedmaterial>
-                        <head></head>
-                        <p></p>
+                        <head>Head tag but no other data</head>
                     </relatedmaterial>
                     <relatedmaterial>
-                        <head>Head tag but no other data</head>
+                        <head></head>
+                        <p></p>
                     </relatedmaterial>
                     <relatedmaterial>
                         <head></head>
@@ -233,6 +219,33 @@
                     </relatedmaterial>
                     <relatedmaterial>
                         <p>Data with no head tag</p>
+                    </relatedmaterial>
+                    <relatedmaterial>
+                        <list></list>
+                    </relatedmaterial>
+                    <relatedmaterial>
+                        <list>
+                            <head></head>
+                            <defitem>
+                                <label></label>
+                                <item></item>
+                            </defitem>
+                        </list>
+                    </relatedmaterial>
+                    <relatedmaterial>
+                        <list>
+                            <head></head>
+                            <defitem>
+                                <label>List data with blank head tag</label>
+                            </defitem>
+                        </list>
+                    </relatedmaterial>
+                    <relatedmaterial>
+                        <list>
+                            <defitem>
+                                <label>List data with no head tag</label>
+                            </defitem>
+                        </list>
                     </relatedmaterial>
                     <scopecontent>
                         <head></head>

--- a/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
@@ -12,6 +12,9 @@
                 </eadheader>
                 <archdesc level="collection">
                     <did>
+                        <repository>
+                            Data not enclosed in subelement
+                        </repository>
                         <unittitle></unittitle>
                         <unittitle>Title string</unittitle>
                         <unittitle>
@@ -123,7 +126,27 @@
                                 </part>
                             </persname>
                         </origination>
+                        <physdesc>
+                            <extent></extent>
+                        </physdesc>
+                        <physdesc>
+                            Data not enclosed in subelement
+                        </physdesc>
                     </did>
+                    <altformavail>
+                        <head></head>
+                        <p></p>
+                    </altformavail>
+                    <altformavail>
+                        <head>Head tag but no other data</head>
+                    </altformavail>
+                    <altformavail>
+                        <head></head>
+                        <p>Data with blank head tag</p>
+                    </altformavail>
+                    <altformavail>
+                        <p>Data with no head tag</p>
+                    </altformavail>
                     <arrangement>
                         <head></head>
                         <p></p>
@@ -179,10 +202,38 @@
                             <emph>Data enclosed in subelement</emph>
                         </geogname>
                     </controlaccess>
+                    <otherfindaid>
+                        <head></head>
+                        <p></p>
+                    </otherfindaid>
+                    <otherfindaid>
+                        <head>Head tag but no other data</head>
+                    </otherfindaid>
+                    <otherfindaid>
+                        <head></head>
+                        <p>Data with blank head tag</p>
+                    </otherfindaid>
+                    <otherfindaid>
+                        <p>Data with no head tag</p>
+                    </otherfindaid>
                     <prefercite>
                         <head></head>
                         <p></p>
                     </prefercite>
+                    <relatedmaterial>
+                        <head></head>
+                        <p></p>
+                    </relatedmaterial>
+                    <relatedmaterial>
+                        <head>Head tag but no other data</head>
+                    </relatedmaterial>
+                    <relatedmaterial>
+                        <head></head>
+                        <p>Data with blank head tag</p>
+                    </relatedmaterial>
+                    <relatedmaterial>
+                        <p>Data with no head tag</p>
+                    </relatedmaterial>
                     <scopecontent>
                         <head></head>
                         <p></p>
@@ -197,6 +248,20 @@
                     <scopecontent>
                         <p>Data with no head tag</p>
                     </scopecontent>
+                    <separatedmaterial>
+                        <head></head>
+                        <p></p>
+                    </separatedmaterial>
+                    <separatedmaterial>
+                        <head>Head tag but no other data</head>
+                    </separatedmaterial>
+                    <separatedmaterial>
+                        <head></head>
+                        <p>Data with blank head tag</p>
+                    </separatedmaterial>
+                    <separatedmaterial>
+                        <p>Data with no head tag</p>
+                    </separatedmaterial>
                 </archdesc>
             </ead>
         </metadata>

--- a/tests/fixtures/ead/ead_record_blank_optional_fields.xml
+++ b/tests/fixtures/ead/ead_record_blank_optional_fields.xml
@@ -28,7 +28,6 @@
                         <genreform></genreform>
                         <geogname></geogname>
                     </controlaccess>
-                    <otherfindaid></otherfindaid>
                     <prefercite></prefercite>
                     <relatedmaterial></relatedmaterial>
                     <scopecontent></scopecontent>

--- a/tests/fixtures/ead/ead_record_blank_optional_fields.xml
+++ b/tests/fixtures/ead/ead_record_blank_optional_fields.xml
@@ -10,6 +10,7 @@
                 <eadheader></eadheader>
                 <archdesc level="collection">
                     <did>
+                        <repository></repository>
                         <unittitle></unittitle>
                         <unitdate></unitdate>
                         <unitid></unitid>
@@ -17,9 +18,9 @@
                         <origination>
                             <persname></persname>
                         </origination>
+                        <physdesc></physdesc>
                     </did>
-                    <acqinfo></acqinfo>
-                    <appraisal></appraisal>
+                    <altformavailable></altformavailable>
                     <arrangement></arrangement>
                     <bibliography></bibliography>
                     <bioghist></bioghist>
@@ -27,10 +28,11 @@
                         <genreform></genreform>
                         <geogname></geogname>
                     </controlaccess>
-                    <custodhist></custodhist>
+                    <otherfindaid></otherfindaid>
                     <prefercite></prefercite>
-                    <processinfo></processinfo>
+                    <relatedmaterial></relatedmaterial>
                     <scopecontent></scopecontent>
+                    <separatedmaterial></separatedmaterial>
                 </archdesc>
             </ead>
         </metadata>

--- a/tests/test_ead.py
+++ b/tests/test_ead.py
@@ -102,8 +102,8 @@ def test_ead_record_all_fields_transform_correctly():
             ),
         ],
         physical_description=(
-            "4.5 Cubic Feet. (10 manuscript boxes, 1 legal manuscript "
-            "box, 1 cassette box)"
+            "4.5 Cubic Feet (10 manuscript boxes, 1 legal manuscript "
+            "box, 1 cassette box); 1.5 Cubic Feet (2 manuscript boxes)"
         ),
         publication_information=[
             "Massachusetts Institute of Technology. Libraries. Department of Distinctive "

--- a/tests/test_ead.py
+++ b/tests/test_ead.py
@@ -101,6 +101,46 @@ def test_ead_record_all_fields_transform_correctly():
                 kind="Scope and Contents",
             ),
         ],
+        physical_description="31 box(es)",
+        publication_information=[
+            "Massachusetts Institute of Technology. Libraries. Department of Distinctive "
+            "Collections"
+        ],
+        related_items=[
+            timdex.RelatedItem(
+                description=(
+                    "A use copy of photographic plates in box 4 can be found in "
+                    "the Institute Archives and Special Collections reading room."
+                ),
+                relationship="Location of Copies",
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "A more detailed collection inventory is available to staff "
+                    "in the MIT ArchivesSpace staff interface."
+                ),
+                relationship="Other Finding Aids",
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "The Charles J. Connick and Associates Archives are located "
+                    "at the Boston Public Library's Fine Arts Department "
+                    "(http://www.bpl.org/research/finearts.htm). The Charles J. Connick "
+                    "papers, 1901-1949 are located at the Smithsonian Archives of "
+                    "American Art "
+                    "(http://www.aaa.si.edu/collections/charles-j-connick-papers-7235). "
+                    "Information on the Charles J. Connick Stained Glass Foundation may "
+                    "be found at their website (http://www.cjconnick.org/)."
+                ),
+                relationship="Related Materials",
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "Issues of Twilight Zine were separated for library cataloging."
+                ),
+                relationship="Separated Materials",
+            ),
+        ],
     )
 
 
@@ -148,8 +188,8 @@ def test_ead_record_with_attribute_and_subfield_variations_transforms_correctly(
             "with blank authfilenumber, Name with blank source, Name with authfile and "
             "source, Name with blank authfile and source, Name with authfile and blank "
             "source, Name with blank authfile and blank source, Contributor with X M L. "
-            "Title string. Archival materials, Correspondence. "
-            "https://archivesspace.mit.edu/repositories/2/resources/6"
+            "Title string. Data not enclosed in subelement. Archival materials, "
+            "Correspondence. https://archivesspace.mit.edu/repositories/2/resources/6"
         ),
         content_type=[
             "Archival materials",
@@ -328,6 +368,42 @@ def test_ead_record_with_attribute_and_subfield_variations_transforms_correctly(
             ),
             timdex.Note(
                 value=["Data with no head tag"], kind="Scope and Contents Note"
+            ),
+        ],
+        physical_description="Data not enclosed in subelement",
+        publication_information=["Data not enclosed in subelement"],
+        related_items=[
+            timdex.RelatedItem(
+                description="Data with blank head tag",
+                relationship="Alternative Form Available",
+            ),
+            timdex.RelatedItem(
+                description="Data with no head tag",
+                relationship="Alternative Form Available",
+            ),
+            timdex.RelatedItem(
+                description="Data with blank head tag",
+                relationship="Other Finding Aid",
+            ),
+            timdex.RelatedItem(
+                description="Data with no head tag",
+                relationship="Other Finding Aid",
+            ),
+            timdex.RelatedItem(
+                description="Data with blank head tag",
+                relationship="Related Material",
+            ),
+            timdex.RelatedItem(
+                description="Data with no head tag",
+                relationship="Related Material",
+            ),
+            timdex.RelatedItem(
+                description="Data with blank head tag",
+                relationship="Separated Material",
+            ),
+            timdex.RelatedItem(
+                description="Data with no head tag",
+                relationship="Separated Material",
             ),
         ],
     )

--- a/tests/test_ead.py
+++ b/tests/test_ead.py
@@ -101,7 +101,10 @@ def test_ead_record_all_fields_transform_correctly():
                 kind="Scope and Contents",
             ),
         ],
-        physical_description="31 box(es)",
+        physical_description=(
+            "4.5 Cubic Feet. (10 manuscript boxes, 1 legal manuscript "
+            "box, 1 cassette box)"
+        ),
         publication_information=[
             "Massachusetts Institute of Technology. Libraries. Department of Distinctive "
             "Collections"
@@ -112,33 +115,61 @@ def test_ead_record_all_fields_transform_correctly():
                     "A use copy of photographic plates in box 4 can be found in "
                     "the Institute Archives and Special Collections reading room."
                 ),
-                relationship="Location of Copies",
-            ),
-            timdex.RelatedItem(
-                description=(
-                    "A more detailed collection inventory is available to staff "
-                    "in the MIT ArchivesSpace staff interface."
-                ),
-                relationship="Other Finding Aids",
-            ),
-            timdex.RelatedItem(
-                description=(
-                    "The Charles J. Connick and Associates Archives are located "
-                    "at the Boston Public Library's Fine Arts Department "
-                    "(http://www.bpl.org/research/finearts.htm). The Charles J. Connick "
-                    "papers, 1901-1949 are located at the Smithsonian Archives of "
-                    "American Art "
-                    "(http://www.aaa.si.edu/collections/charles-j-connick-papers-7235). "
-                    "Information on the Charles J. Connick Stained Glass Foundation may "
-                    "be found at their website (http://www.cjconnick.org/)."
-                ),
-                relationship="Related Materials",
+                relationship="Alternate Format",
             ),
             timdex.RelatedItem(
                 description=(
                     "Issues of Twilight Zine were separated for library cataloging."
                 ),
-                relationship="Separated Materials",
+                relationship="Separated Material",
+            ),
+            timdex.RelatedItem(
+                description="MC-0423 James R. Killian Papers",
+            ),
+            timdex.RelatedItem(
+                description="MC-0416 Karl T. Compton Papers",
+            ),
+            timdex.RelatedItem(
+                description="MC-0029 Carroll Wilson Papers",
+            ),
+            timdex.RelatedItem(
+                description="MC-0060 George Russell Harrison Papers",
+            ),
+            timdex.RelatedItem(
+                description="MC-0351 Margaret Compton Papers",
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "AC-0132 Office of the Chancellor; Records of Provost Julius "
+                    "A. Stratton, Vice President and Provost Julius A. Stratton, and "
+                    "Chancellor Julius A. Stratton"
+                )
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "AC-0333 Office of the Vice President, Records of Vannevar Bush"
+                ),
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "The Charles J. Connick and Associates Archives are located "
+                    "at the Boston Public Library's Fine Arts Department "
+                    "(http://www.bpl.org/research/finearts.htm)."
+                ),
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "The Charles J. Connick papers, 1901-1949 are located at the "
+                    "Smithsonian Archives of American Art "
+                    "(http://www.aaa.si.edu/collections/charles-j-connick-papers-7235)."
+                ),
+            ),
+            timdex.RelatedItem(
+                description=(
+                    "Information on the Charles J. Connick Stained Glass "
+                    "Foundation may be found at their website "
+                    "(http://www.cjconnick.org/)."
+                ),
             ),
         ],
     )
@@ -375,27 +406,11 @@ def test_ead_record_with_attribute_and_subfield_variations_transforms_correctly(
         related_items=[
             timdex.RelatedItem(
                 description="Data with blank head tag",
-                relationship="Alternative Form Available",
+                relationship="Alternate Format",
             ),
             timdex.RelatedItem(
                 description="Data with no head tag",
-                relationship="Alternative Form Available",
-            ),
-            timdex.RelatedItem(
-                description="Data with blank head tag",
-                relationship="Other Finding Aid",
-            ),
-            timdex.RelatedItem(
-                description="Data with no head tag",
-                relationship="Other Finding Aid",
-            ),
-            timdex.RelatedItem(
-                description="Data with blank head tag",
-                relationship="Related Material",
-            ),
-            timdex.RelatedItem(
-                description="Data with no head tag",
-                relationship="Related Material",
+                relationship="Alternate Format",
             ),
             timdex.RelatedItem(
                 description="Data with blank head tag",
@@ -404,6 +419,18 @@ def test_ead_record_with_attribute_and_subfield_variations_transforms_correctly(
             timdex.RelatedItem(
                 description="Data with no head tag",
                 relationship="Separated Material",
+            ),
+            timdex.RelatedItem(
+                description="Data with blank head tag",
+            ),
+            timdex.RelatedItem(
+                description="Data with no head tag",
+            ),
+            timdex.RelatedItem(
+                description="List data with blank head tag",
+            ),
+            timdex.RelatedItem(
+                description="List data with no head tag",
             ),
         ],
     )

--- a/transmogrifier/sources/ead.py
+++ b/transmogrifier/sources/ead.py
@@ -203,11 +203,11 @@ class Ead(Transformer):
             "physdesc", recursive=False
         ):
             if physical_description_value := self.create_string_from_mixed_value(
-                physical_description_element, ". "
+                physical_description_element, " "
             ):
                 physical_descriptions.append(physical_description_value)
         if physical_descriptions:
-            fields["physical_description"] = ". ".join(physical_descriptions)
+            fields["physical_description"] = "; ".join(physical_descriptions)
 
         # publication_frequency field not used in EAD
 


### PR DESCRIPTION
#### How can a reviewer manually see the effects of these changes?
Run the transform locally using the `aspace-full-harvested-records-2022-08-19.xml` file in the dev S3 bucket, e.g.:

```
pipenv run transform -i <S3 URL for file above> -o aspace-timdex.json -s aspace
```

#### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/TIMX-64

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
NO