### PR TITLE
TIMX-64-complete-get-optional-fields

### DIFF
--- a/tests/fixtures/ead/ead_record_all_fields.xml
+++ b/tests/fixtures/ead/ead_record_all_fields.xml
@@ -36,6 +36,11 @@
                         <unitid>
                             1234
                         </unitid>
+                        <abstract>
+                            A record of the
+                            <emph>MIT</emph>
+                            faculty begins with the minutes of the September 25, 1865, meeting and continues to the present day. Among the topics discussed at faculty meetings are proposed degree programs, disciplinary actions, admission and graduation requirements, enrollment and diversity, and issues concerning student life. This collection includes biographical material in Killian Award and Edgerton Award announcements and resolutions on the death of individual faculty members written by faculty peers. Minutes may also contain reports produced by committees and task forces as their results are reported and discussed at faculty meetings.
+                        </abstract>
                         <langmaterial>
                             <language>English</language>
                             ,
@@ -73,6 +78,10 @@
                             <extent>(2 manuscript boxes)</extent>
                         </physdesc>
                     </did>
+                    <accessrestrict>
+                        <head>Conditions Governing Access</head>
+                        <p>This collection is open.</p>
+                    </accessrestrict>
                     <altformavail>
                         <head>Location of Copies</head>
                         <p>A use copy of photographic plates in box 4 can be found in the Institute Archives and Special Collections reading room.</p>
@@ -109,6 +118,10 @@
                             <part>Correspondence</part>
                         </genreform>
                         <geogname>Boston, MA</geogname>
+                        <subject source="aat">Letters (Correspondence)</subject>
+                        <famname source="local">Hutchinson Family</famname>
+                        <persname source="local">Hutchinson, John C.</persname>
+                        <corpname source="naf">University of Minnesota</corpname>
                     </controlaccess>
                     <prefercite>
                         <head>Preferred Citation</head>
@@ -167,6 +180,12 @@
                         <head>Separated Materials</head>
                         <p>Issues of Twilight Zine were separated for library cataloging.</p>
                     </separatedmaterial>
+                    <userestrict>
+                        <head>Conditions Governing Use</head>
+                        <p>
+                            Access to collections in the Department of Distinctive Collections is not authorization to publish. Please see the MIT Libraries Permissions Policy for permission information. Copyright of some items in this collection may be held by respective creators, not by the donor of the collection or MIT.
+                        </p>
+                    </userestrict>
                 </archdesc>
             </ead>
         </metadata>

--- a/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
@@ -53,6 +53,9 @@
                         <unitid>
                             <emph>Data enclosed in subelement</emph>
                         </unitid>
+                        <abstract>
+                            <emph>Data enclosed in subelement</emph>
+                        </abstract>
                         <langmaterial>
                             <language></language>
                         </langmaterial>
@@ -133,6 +136,13 @@
                             Data not enclosed in subelement
                         </physdesc>
                     </did>
+                    <accessrestrict>
+                        <head></head>
+                        <p></p>
+                    </accessrestrict>
+                    <accessrestrict>
+                        <head>Head tag but no other data</head>
+                    </accessrestrict>
                     <altformavail>
                         <head></head>
                         <p></p>
@@ -201,6 +211,14 @@
                         <geogname>
                             <emph>Data enclosed in subelement</emph>
                         </geogname>
+                        <subject source=""></subject>
+                        <subject source="">Subject with blank source attribute</subject>
+                        <subject>
+                            <emph>Data enclosed in subelement</emph>
+                        </subject>
+                        <subject source="">
+                            <emph>Data enclosed in subelement with blank source attribute</emph>
+                        </subject>
                     </controlaccess>
                     <prefercite>
                         <head></head>
@@ -275,6 +293,13 @@
                     <separatedmaterial>
                         <p>Data with no head tag</p>
                     </separatedmaterial>
+                    <userestrict>
+                        <head></head>
+                        <p></p>
+                    </userestrict>
+                    <userestrict>
+                        <head>Head tag but no other data</head>
+                    </userestrict>
                 </archdesc>
             </ead>
         </metadata>

--- a/tests/fixtures/ead/ead_record_blank_optional_fields.xml
+++ b/tests/fixtures/ead/ead_record_blank_optional_fields.xml
@@ -14,12 +14,14 @@
                         <unittitle></unittitle>
                         <unitdate></unitdate>
                         <unitid></unitid>
+                        <abstract></abstract>
                         <langmaterial></langmaterial>
                         <origination>
                             <persname></persname>
                         </origination>
                         <physdesc></physdesc>
                     </did>
+                    <accessrestrict></accessrestrict>
                     <altformavailable></altformavailable>
                     <arrangement></arrangement>
                     <bibliography></bibliography>
@@ -27,11 +29,16 @@
                     <controlaccess>
                         <genreform></genreform>
                         <geogname></geogname>
+                        <subject></subject>
+                        <famname></famname>
+                        <corpname></corpname>
+                        <persname></persname>
                     </controlaccess>
                     <prefercite></prefercite>
                     <relatedmaterial></relatedmaterial>
                     <scopecontent></scopecontent>
                     <separatedmaterial></separatedmaterial>
+                    <userestrict></userestrict>
                 </archdesc>
             </ead>
         </metadata>

--- a/tests/test_ead.py
+++ b/tests/test_ead.py
@@ -172,6 +172,46 @@ def test_ead_record_all_fields_transform_correctly():
                 ),
             ),
         ],
+        rights=[
+            timdex.Rights(
+                description="This collection is open.",
+                kind="Conditions Governing Access",
+            ),
+            timdex.Rights(
+                description=(
+                    "Access to collections in the Department of Distinctive "
+                    "Collections is not authorization to publish. Please see the MIT "
+                    "Libraries Permissions Policy for permission information. Copyright "
+                    "of some items in this collection may be held by respective "
+                    "creators, not by the donor of the collection or MIT."
+                ),
+                kind="Conditions Governing Use",
+            ),
+        ],
+        subjects=[
+            timdex.Subject(value=["Correspondence"]),
+            timdex.Subject(value=["Boston, MA"]),
+            timdex.Subject(
+                value=["Letters (Correspondence)"], kind="Art & Architecture Thesaurus"
+            ),
+            timdex.Subject(value=["Hutchinson Family"], kind="local"),
+            timdex.Subject(value=["Hutchinson, John C."], kind="local"),
+            timdex.Subject(
+                value=["University of Minnesota"],
+                kind="Library of Congress Name Authority File",
+            ),
+        ],
+        summary=[
+            "A record of the MIT faculty begins with the minutes of the September 25, "
+            "1865, meeting and continues to the present day. Among the topics discussed "
+            "at faculty meetings are proposed degree programs, disciplinary actions, "
+            "admission and graduation requirements, enrollment and diversity, and issues "
+            "concerning student life. This collection includes biographical material in "
+            "Killian Award and Edgerton Award announcements and resolutions on the death "
+            "of individual faculty members written by faculty peers. Minutes may also "
+            "contain reports produced by committees and task forces as their results are "
+            "reported and discussed at faculty meetings."
+        ],
     )
 
 
@@ -433,6 +473,16 @@ def test_ead_record_with_attribute_and_subfield_variations_transforms_correctly(
                 description="List data with no head tag",
             ),
         ],
+        subjects=[
+            timdex.Subject(value=["Correspondence"]),
+            timdex.Subject(value=["Data enclosed in subelement"]),
+            timdex.Subject(value=["Subject with blank source attribute"]),
+            timdex.Subject(value=["Data enclosed in subelement"]),
+            timdex.Subject(
+                value=["Data enclosed in subelement with blank source attribute"]
+            ),
+        ],
+        summary=["Data enclosed in subelement"],
     )
 
 


### PR DESCRIPTION
#### How can a reviewer manually see the effects of these changes?
Run the transform locally using the `aspace-full-harvested-records-2022-08-19.xml` file in the dev S3 bucket, e.g.:

```
pipenv run transform -i <S3 URL for file above> -o aspace-timdex.json -s aspace
```
#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/TIMX-64

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
NO