### PR TITLE
Skip deleted records during transform

### DIFF
--- a/tests/fixtures/oai_pmh_records.xml
+++ b/tests/fixtures/oai_pmh_records.xml
@@ -6,4 +6,8 @@
     <record xmlns="http://www.openarchives.org/OAI/2.0/"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     </record>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <header status="deleted"></header>
+    </record>
 </metadata>

--- a/tests/fixtures/record_deleted.xml
+++ b/tests/fixtures/record_deleted.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header status="deleted">
+        <identifier>123456</identifier>
+        <datestamp>2022-11-30T16:53:47Z</datestamp>
+    </header>
+</record>

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -17,6 +17,9 @@ def test_transformer_initializes_with_expected_attributes(oai_pmh_records):
 def test_transformer_iterates_through_all_records(oai_pmh_records):
     output_records = Transformer("cool-repo", oai_pmh_records)
     assert len(list(output_records)) == 2
+    assert output_records.processed_record_count == 3
+    assert output_records.skipped_record_count == 1
+    assert output_records.transformed_record_count == 2
 
 
 def test_transformer_iterates_successfully_if_get_optional_fields_returns_none(
@@ -28,9 +31,16 @@ def test_transformer_iterates_successfully_if_get_optional_fields_returns_none(
         m.return_value = None
         output_records = Transformer("cool-repo", oai_pmh_records)
         assert len(list(output_records)) == 0
-        assert output_records.processed_record_count == 2
-        assert output_records.skipped_record_count == 2
+        assert output_records.processed_record_count == 3
+        assert output_records.skipped_record_count == 3
         assert output_records.transformed_record_count == 0
+
+
+def test_transformer_record_is_deleted_returns_true_if_deleted(caplog):
+    input_records = parse_xml_records("tests/fixtures/record_deleted.xml")
+    output_records = Datacite("cool-repo", input_records)
+    assert len(list(output_records)) == 0
+    assert "Skipping record 123456 with header status deleted" in caplog.text
 
 
 def test_transformer_get_required_fields_returns_expected_values(oai_pmh_records):

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -87,6 +87,25 @@ class Transformer(object):
         """
         return ""
 
+    @classmethod
+    @abstractmethod
+    def record_is_deleted(cls, xml: Tag) -> bool:
+        """
+        Determine whether record has a status of deleted.
+
+        May be overridden by source subclasses if needed.
+
+        Args:
+            xml: A BeautifulSoup Tag representing a single XML record
+        """
+        if xml.find("header", status="deleted"):
+            logger.debug(
+                f"Skipping record {cls.get_source_record_id(xml)} with header status "
+                "deleted"
+            )
+            return True
+        return False
+
     @final
     def get_required_fields(self, xml: Tag) -> dict:
         """
@@ -116,6 +135,8 @@ class Transformer(object):
         Args:
             xml: A BeautifulSoup Tag representing a single OAI-PMH XML record.
         """
+        if self.record_is_deleted(xml):
+            return None
         optional_fields = self.get_optional_fields(xml)
         if optional_fields is None:
             return None


### PR DESCRIPTION
#### What does this PR do?
Adds functionality to skip deleted records during transform so they don't raise errors. This is a temporary solution until we're ready to add actual deleted record handling.

#### How can a reviewer manually see the effects of these changes?
Run a transform on the latest ASpace daily update file, which includes two deleted records (aspace-2022-11-30-daily-extracted-records-to-index.xml in the dev S3 bucket):
```
pipenv run transform -i <path-to-file-above> -o output/aspace-transform.json -s aspace
```
There should be 6 total records processed, 4 transformed and 2 skipped.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-126

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
NO