### PR TITLE
Fix file open bug for s3

### DIFF
--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -84,7 +84,7 @@ def parse_xml_records(
 
 
 def write_deleted_records_to_file(deleted_records: list[str], output_file_path: str):
-    with open(output_file_path, "a") as file:
+    with open(output_file_path, "w") as file:
         for record_id in deleted_records:
             file.write(f"{record_id}\n")
 


### PR DESCRIPTION
### What does this PR do?
Changes the file open mode for helpers.write_deleted_records_to_file() to write.

### Helpful background context
Due to current weirdness with the Alma records, the deleted records output file was opened in append mode to ensure we didn't overwrite deleted records that may show up in the wrong export file. However, smart_open doesn't implement append mode in its open() function with S3 files so this needs to revert to write mode.

Deleted records during Alma export may not be 100% accurate until the current Alma record export issue is fixed. The metadata team is working on it and we will just have to do a full re-ingest once that's done to ensure we have accurate data in TIMDEX.
