### PR TITLE
Fix bs4 recursion issue

### DIFF
--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import sys
 from datetime import datetime
 from typing import Iterator, Optional
 
@@ -17,6 +18,9 @@ from transmogrifier.config import DATE_FORMATS
 from transmogrifier.models import TimdexRecord
 
 logger = logging.getLogger(__name__)
+
+
+sys.setrecursionlimit(10000)
 
 
 def generate_citation(extracted_data: dict) -> str:


### PR DESCRIPTION
#### What does this PR do?
In the helpers module where this issue occured, sets Python's internal recursion limit to 10000 instead of the default 1000.

#### Helpful background context
During processing of one set of deleted Alma records, bs4's internal process was hitting Python's internal recursion limit. Raising the recursion limit seems to solve the issue without a notable impact on performance.

#### How can a reviewer manually see the effects of these changes?
On the current main branch, try to transform the Alma file that was causing issues and you should hit the same error we did on prod (I copied the file to Dev1 for easier testing):
```
 pipenv run transform -i s3://timdex-extract-dev-222053980223/alma/alma-2023-03-07-daily-extracted-records-to-delete.xml -o output/alma-deletes.json -s alma
```
Then checkout this branch and run the same transform. It should complete successfully.

#### Includes new or updated dependencies?
NO

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes