### PR TITLE
Fix recursion bug

### DIFF
--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -40,19 +40,20 @@ class Transformer(object):
 
     def __next__(self) -> TimdexRecord:
         """Return next transformed record."""
-        xml = next(self.input_records)
-        self.processed_record_count += 1
-        try:
-            record = self.transform(xml)
-        except DeletedRecord as error:
-            self.deleted_records.append(error.timdex_record_id)
-            return self.__next__()
-        if record:
-            self.transformed_record_count += 1
-            return record
-        else:
-            self.skipped_record_count += 1
-            return self.__next__()
+        while True:
+            xml = next(self.input_records)
+            self.processed_record_count += 1
+            try:
+                record = self.transform(xml)
+            except DeletedRecord as error:
+                self.deleted_records.append(error.timdex_record_id)
+                continue
+            if record:
+                self.transformed_record_count += 1
+                return record
+            else:
+                self.skipped_record_count += 1
+                continue
 
     @abstractmethod
     def get_optional_fields(self, xml: Tag) -> Optional[dict]:


### PR DESCRIPTION
#### What does this PR do?
Replaces recursive call in the Transformer class `__next__` method with an internal loop.

#### Helpful background context
The Transformer's internal `__next__` method used recursion to skip over records that couldn't be transformed, which was both inefficient and hit a recursion depth limit while processing deletes (none of which are transformed).

#### How can a reviewer manually see the effects of these changes?
On the current main branch, try to transform the Alma file that was causing issues and you should hit the same error we did on prod (I copied the file to Dev1 for easier testing):
```
 pipenv run transform -i s3://timdex-extract-dev-222053980223/alma/alma-2023-03-07-daily-extracted-records-to-delete.xml -o output/alma-deletes.json -s alma
```
Then checkout this branch and run the same transform. It should complete successfully.

#### Includes new or updated dependencies?
NO

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
- [ ] Why these changes are being introduced: