### PR TITLE
date-whitespace-bug-fix

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -264,14 +264,19 @@ def test_parse_date_from_string_invalid_date_returns_none():
 
 
 def test_validate_date_success():
-    assert validate_date("1930 ", "1234") is True
+    assert validate_date("1930", "1234") is True
 
 
 def test_validate_date_invalid_date_logs_error(caplog):
     assert validate_date("circa 1930s", "1234") is False
     assert (
-        "Record # '1234' has a date that couldn't be parsed: circa 1930s"
+        "Record # '1234' has a date that couldn't be parsed: 'circa 1930s'"
     ) in caplog.text
+
+
+def test_validate_date_whitespace_date_logs_error(caplog):
+    assert validate_date("30  ", "1234") is False
+    assert ("Record # '1234' has a date that couldn't be parsed: '30  '") in caplog.text
 
 
 def test_validate_date_range_success():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -198,7 +198,6 @@ def test_parse_date_from_string_success():
     for date in [
         "1930",
         "1930-12",
-        "30",
         "30-12",
         "30-12-31",
         "1930-12-31",
@@ -275,8 +274,10 @@ def test_validate_date_invalid_date_logs_error(caplog):
 
 
 def test_validate_date_whitespace_date_logs_error(caplog):
-    assert validate_date("30  ", "1234") is False
-    assert ("Record # '1234' has a date that couldn't be parsed: '30  '") in caplog.text
+    assert validate_date("1930  ", "1234") is False
+    assert (
+        "Record # '1234' has a date that couldn't be parsed: '1930  '"
+    ) in caplog.text
 
 
 def test_validate_date_range_success():

--- a/transmogrifier/config.py
+++ b/transmogrifier/config.py
@@ -14,7 +14,6 @@ DATE_FORMATS = [
     "%Y",  # strict_year
     "%Y-%m",  # strict_year_month
     # date variations
-    "%y",
     "%y-%m",
     "%y-%m-%d",
     "%Y-%m-%d",

--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -116,12 +116,11 @@ def validate_date(
         date_string: A date string.
         source_record_id: The ID of the record being transformed.
     """
-    date_string = date_string.strip()
     if parse_date_from_string(date_string):
         return True
     else:
         logger.debug(
-            "Record # '%s' has a date that couldn't be parsed: %s",
+            "Record # '%s' has a date that couldn't be parsed: '%s'",
             source_record_id,
             date_string,
         )

--- a/transmogrifier/sources/datacite.py
+++ b/transmogrifier/sources/datacite.py
@@ -120,7 +120,7 @@ class Datacite(Transformer):
 
         for date in xml.metadata.find_all("date"):
             d = timdex.Date()
-            if date_value := date.string:
+            if date_value := str(date.string):
                 if "/" in date_value:
                     split = date_value.index("/")
                     gte_date = date_value[:split].strip()

--- a/transmogrifier/sources/datacite.py
+++ b/transmogrifier/sources/datacite.py
@@ -107,11 +107,14 @@ class Datacite(Transformer):
 
         # dates
         if publication_year := xml.metadata.find("publicationYear", string=True):
-            fields["dates"] = [
-                timdex.Date(
-                    kind="Publication date", value=publication_year.string.strip()
-                )
-            ]
+            publication_year = str(publication_year.string.strip())
+            if validate_date(
+                publication_year,
+                source_record_id,
+            ):
+                fields["dates"] = [
+                    timdex.Date(kind="Publication date", value=publication_year)
+                ]
         else:
             logger.warning(
                 "Datacite record %s missing required Datacite field publicationYear",
@@ -120,7 +123,8 @@ class Datacite(Transformer):
 
         for date in xml.metadata.find_all("date"):
             d = timdex.Date()
-            if date_value := str(date.string):
+            if date_value := date.string:
+                date_value = str(date_value)
                 if "/" in date_value:
                     split = date_value.index("/")
                     gte_date = date_value[:split].strip()

--- a/transmogrifier/sources/datacite.py
+++ b/transmogrifier/sources/datacite.py
@@ -108,7 +108,9 @@ class Datacite(Transformer):
         # dates
         if publication_year := xml.metadata.find("publicationYear", string=True):
             fields["dates"] = [
-                timdex.Date(kind="Publication date", value=publication_year.string)
+                timdex.Date(
+                    kind="Publication date", value=publication_year.string.strip()
+                )
             ]
         else:
             logger.warning(
@@ -121,8 +123,8 @@ class Datacite(Transformer):
             if date_value := date.string:
                 if "/" in date_value:
                     split = date_value.index("/")
-                    gte_date = date_value[:split]
-                    lte_date = date_value[split + 1 :]
+                    gte_date = date_value[:split].strip()
+                    lte_date = date_value[split + 1 :].strip()
                     if validate_date_range(
                         gte_date,
                         lte_date,
@@ -134,7 +136,7 @@ class Datacite(Transformer):
                         )
                 else:
                     d.value = (
-                        date_value
+                        date_value.strip()
                         if validate_date(
                             date_value,
                             source_record_id,

--- a/transmogrifier/sources/dspace_dim.py
+++ b/transmogrifier/sources/dspace_dim.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 from bs4 import Tag
 
 import transmogrifier.models as timdex
-from transmogrifier.helpers import validate_date_range
+from transmogrifier.helpers import validate_date, validate_date_range
 from transmogrifier.sources.transformer import Transformer
 
 logger = logging.getLogger(__name__)
@@ -88,13 +88,15 @@ class DspaceDim(Transformer):
 
         # dates
         for date in [d for d in xml.find_all("dim:field", element="date") if d.string]:
-            if date.get("qualifier") == "issued":
-                d = timdex.Date(value=date.string.strip(), kind="Publication date")
-            else:
-                d = timdex.Date(
-                    value=date.string.strip(), kind=date.get("qualifier") or None
-                )
-            fields.setdefault("dates", []).append(d)
+            date_value = str(date.string.strip())
+            if validate_date(date_value, source_record_id):
+                if date.get("qualifier") == "issued":
+                    d = timdex.Date(value=date_value, kind="Publication date")
+                else:
+                    d = timdex.Date(
+                        value=date_value, kind=date.get("qualifier") or None
+                    )
+                fields.setdefault("dates", []).append(d)
 
         for coverage in [
             c.string

--- a/transmogrifier/sources/dspace_dim.py
+++ b/transmogrifier/sources/dspace_dim.py
@@ -89,9 +89,11 @@ class DspaceDim(Transformer):
         # dates
         for date in [d for d in xml.find_all("dim:field", element="date") if d.string]:
             if date.get("qualifier") == "issued":
-                d = timdex.Date(value=date.string, kind="Publication date")
+                d = timdex.Date(value=date.string.strip(), kind="Publication date")
             else:
-                d = timdex.Date(value=date.string, kind=date.get("qualifier") or None)
+                d = timdex.Date(
+                    value=date.string.strip(), kind=date.get("qualifier") or None
+                )
             fields.setdefault("dates", []).append(d)
 
         for coverage in [

--- a/transmogrifier/sources/dspace_dim.py
+++ b/transmogrifier/sources/dspace_dim.py
@@ -87,7 +87,7 @@ class DspaceDim(Transformer):
             )
 
         # dates
-        for date in [d for d in xml.find_all("dim:field", element="date") if d.string]:
+        for date in xml.find_all("dim:field", element="date", string=True):
             date_value = str(date.string.strip())
             if validate_date(date_value, source_record_id):
                 if date.get("qualifier") == "issued":

--- a/transmogrifier/sources/dspace_mets.py
+++ b/transmogrifier/sources/dspace_mets.py
@@ -77,7 +77,7 @@ class DspaceMets(Transformer):
         # Only publication date is mapped from DSpace, other relevant date field (dc.
         # coverage.temporal) is not mapped to the OAI-PMH METS output.
         if publication_date := xml.find("mods:dateIssued", string=True):
-            publication_date_value = publication_date.string
+            publication_date_value = publication_date.string.strip()
             if validate_date(publication_date_value, source_record_id):
                 fields["dates"] = [
                     timdex.Date(kind="Publication date", value=publication_date_value)

--- a/transmogrifier/sources/dspace_mets.py
+++ b/transmogrifier/sources/dspace_mets.py
@@ -77,7 +77,7 @@ class DspaceMets(Transformer):
         # Only publication date is mapped from DSpace, other relevant date field (dc.
         # coverage.temporal) is not mapped to the OAI-PMH METS output.
         if publication_date := xml.find("mods:dateIssued", string=True):
-            publication_date_value = publication_date.string.strip()
+            publication_date_value = str(publication_date.string.strip())
             if validate_date(publication_date_value, source_record_id):
                 fields["dates"] = [
                     timdex.Date(kind="Publication date", value=publication_date_value)

--- a/transmogrifier/sources/ead.py
+++ b/transmogrifier/sources/ead.py
@@ -112,8 +112,8 @@ class Ead(Transformer):
                 date_instance = timdex.Date()
                 if "-" in date_value:
                     split = date_value.index("-")
-                    gte_date = date_value[:split]
-                    lte_date = date_value[split + 1 :]
+                    gte_date = date_value[:split].strip()
+                    lte_date = date_value[split + 1 :].strip()
                     if validate_date_range(
                         gte_date,
                         lte_date,
@@ -125,7 +125,7 @@ class Ead(Transformer):
                         )
                 else:
                     date_instance.value = (
-                        date_value
+                        date_value.strip()
                         if validate_date(
                             date_value,
                             source_record_id,

--- a/transmogrifier/sources/marc.py
+++ b/transmogrifier/sources/marc.py
@@ -208,7 +208,7 @@ class Marc(Transformer):
         fields["contributors"] = contributor_values or None
 
         # dates
-        publication_year = str(fixed_length_data.string)[7:11]
+        publication_year = str(fixed_length_data.string)[7:11].strip()
         if validate_date(publication_year, source_record_id):
             fields["dates"] = [
                 timdex.Date(kind="Publication date", value=publication_year)


### PR DESCRIPTION
#### Helpful background context
Though `Marc` is the transform most likely to encounter this issue, I updated the date processing for all of the transforms. Let me know if this overkill.

#### How can a reviewer manually see the effects of these changes?
I uploaded a file with a whitespace date to dev1. Run the following command on `main` to see that the whitespace is in the output and then with `date-whitespace-bug-fix` to see that the date appears without whitespace:

```
pipenv run transform -i s3://timdex-extract-dev-222053980223/alma/date-error.xml -o output/date-error-transformed-records.json -s alma
```

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
NO