### PR TITLE
TIMX-212-invalid-date-fix

### DIFF
--- a/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
@@ -38,15 +38,21 @@
                         <unitdate datechar="creation"></unitdate>
                         <unitdate datechar="creation">1905-2012</unitdate>
                         <unitdate datechar="creation">1905</unitdate>
+                        <unitdate datechar="creation">abcd-efgh</unitdate>
+                        <unitdate datechar="creation">abcd</unitdate>
                         <unitdate datechar="creation" certainty=""></unitdate>
                         <unitdate datechar="creation" certainty="">1905-2012</unitdate>
                         <unitdate datechar="creation" certainty="">1905</unitdate>
                         <unitdate datechar="creation" certainty="approximate"></unitdate>
                         <unitdate datechar="creation" certainty="approximate">1905-2012</unitdate>
                         <unitdate datechar="creation" certainty="approximate">1905</unitdate>
+                        <unitdate datechar="creation" certainty="approximate">abcd-efgh</unitdate>
+                        <unitdate datechar="creation" certainty="approximate">abcd</unitdate>
                         <unitdate certainty="approximate"></unitdate>
                         <unitdate certainty="approximate">1905-2012</unitdate>
                         <unitdate certainty="approximate">1905</unitdate>
+                        <unitdate certainty="approximate">abcd-efgh</unitdate>
+                        <unitdate certainty="approximate">abcd</unitdate>
                         <unitdate datechar="" certainty="approximate"></unitdate>
                         <unitdate datechar="" certainty="approximate">1905-2012</unitdate>
                         <unitdate datechar="" certainty="approximate">1905</unitdate>

--- a/tests/test_ead.py
+++ b/tests/test_ead.py
@@ -504,6 +504,28 @@ def test_ead_record_with_blank_optional_fields_transforms_correctly():
     )
 
 
+def test_ead_record_invalid_date_and_date_range_are_omitted(caplog):
+    ead_xml_records = parse_xml_records(
+        "tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml"
+    )
+    output_record = next(Ead("aspace", ead_xml_records))
+    assert "abcd" not in [d.value for d in output_record.dates]
+    assert "abcd" not in [
+        d.range.gte for d in output_record.dates if "gte" in dir(d.range)
+    ]
+    assert "efgh" not in [
+        d.range.lte for d in output_record.dates if "lte" in dir(d.range)
+    ]
+    assert (
+        "Record ID 'repositories/2/resources/6' has invalid values in a date range: "
+        "'abcd', 'efgh'"
+    ) in caplog.text
+    assert (
+        "Record ID 'repositories/2/resources/6' has a date that couldn't be parsed: "
+        "'abcd'"
+    ) in caplog.text
+
+
 def test_ead_record_with_missing_optional_fields_transforms_correctly():
     ead_xml_records = parse_xml_records(
         "tests/fixtures/ead/ead_record_missing_optional_fields.xml"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -269,14 +269,14 @@ def test_validate_date_success():
 def test_validate_date_invalid_date_logs_error(caplog):
     assert validate_date("circa 1930s", "1234") is False
     assert (
-        "Record # '1234' has a date that couldn't be parsed: 'circa 1930s'"
+        "Record ID '1234' has a date that couldn't be parsed: 'circa 1930s'"
     ) in caplog.text
 
 
 def test_validate_date_whitespace_date_logs_error(caplog):
     assert validate_date("1930  ", "1234") is False
     assert (
-        "Record # '1234' has a date that couldn't be parsed: '1930  '"
+        "Record ID '1234' has a date that couldn't be parsed: '1930  '"
     ) in caplog.text
 
 
@@ -287,7 +287,7 @@ def test_validate_date_range_success():
 def test_validate_date_range_invalid_date_range_logs_error(caplog):
     assert validate_date_range("circa 1910s", "1924", "1234") is False
     assert (
-        "Record ID '1234' has an invalid values in a date range: 'circa 1910s', '1924'"
+        "Record ID '1234' has invalid values in a date range: 'circa 1910s', '1924'"
     ) in caplog.text
 
 

--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -120,7 +120,7 @@ def validate_date(
         return True
     else:
         logger.debug(
-            "Record # '%s' has a date that couldn't be parsed: '%s'",
+            "Record ID '%s' has a date that couldn't be parsed: '%s'",
             source_record_id,
             date_string,
         )
@@ -158,7 +158,7 @@ def validate_date_range(
             return False
     else:
         logger.debug(
-            "Record ID '%s' has an invalid values in a date range: '%s', '%s'",
+            "Record ID '%s' has invalid values in a date range: '%s', '%s'",
             source_record_id,
             start_date,
             end_date,

--- a/transmogrifier/sources/ead.py
+++ b/transmogrifier/sources/ead.py
@@ -132,9 +132,10 @@ class Ead(Transformer):
                         )
                         else None
                     )
-                date_instance.kind = date_element.get("datechar") or None
-                date_instance.note = date_element.get("certainty") or None
-                fields.setdefault("dates", []).append(date_instance)
+                if date_instance.range or date_instance.value:
+                    date_instance.kind = date_element.get("datechar") or None
+                    date_instance.note = date_element.get("certainty") or None
+                    fields.setdefault("dates", []).append(date_instance)
 
         # edition field not used in EAD
 


### PR DESCRIPTION
#### Helpful background context
After reviewing all the transforms, `Ead` appears to be the only one that was affected by this bug.

#### How can a reviewer manually see the effects of these changes?
Before pulling down the new branch, run the following command with `main` while authenticated to dev:

```
pipenv run transform -i s3://timdex-extract-dev-222053980223/aspace/aspace-2023-10-17-full-extracted-records-to-index.xml -o output/aspace-records.json -s aspace
```
Check record `aspace:repositories-2-resources-531` and see the invalid date. 

Fetch `TIMX-212-invalid-date-fix` and run the same command to see that the invalid date has been omitted.


#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/TIMX-212

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
NO