### PR TITLE
Update type hints in helpers.write_timdex_records_to_json

### DIFF
--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from datetime import datetime
-from typing import Iterator, Optional
+from typing import Iterator, Optional, TYPE_CHECKING
 
 from attrs import asdict
 from bs4 import BeautifulSoup, Tag
@@ -15,6 +15,10 @@ from smart_open import open
 
 from transmogrifier.config import DATE_FORMATS
 from transmogrifier.models import TimdexRecord
+
+# import Transformer only when type checking to avoid circular dependency
+if TYPE_CHECKING:  # pragma: no cover
+    from transmogrifier.sources.transformer import Transformer
 
 logger = logging.getLogger(__name__)
 
@@ -173,11 +177,11 @@ def write_deleted_records_to_file(deleted_records: list[str], output_file_path: 
 
 
 def write_timdex_records_to_json(
-    records: Iterator[TimdexRecord], output_file_path: str
+    transformer_instance: "Transformer", output_file_path: str
 ) -> int:
     count = 0
     try:
-        record = next(records)
+        record: TimdexRecord = next(transformer_instance)
     except StopIteration:
         return count
     with open(output_file_path, "w") as file:
@@ -195,7 +199,7 @@ def write_timdex_records_to_json(
                     "Status update: %s records written to output file so far!", count
                 )
             try:
-                record = next(records)
+                record: TimdexRecord = next(transformer_instance)  # type: ignore
             except StopIteration:
                 break
             file.write(",\n")


### PR DESCRIPTION
#### Helpful background context

While onboarding and reading through the codebase to understand how it works, I found myself tripping on a variable name and type in the `helpers.write_timdex_records_to_json` function that the CLI calls.

It looks as though sometime last year, the `Transformer` class had an interator pattern introduced that slightly changed downstream types.  Instead of passing an iterator of records, an actual `Transformer` instance is passed, where calling `next(transformer_instance)` will produce a _transformed_ record.

#### How can a reviewer manually see the effects of these changes?

No changes to functionality of code, just type hints.

Can confirm that all testing and linting passes:
```bash
make test
make lint
```

And, can confirm via built-in type hinting from an IDE that the types are correct:
<img width="572" alt="Screenshot 2023-07-17 at 3 53 42 PM" src="https://github.com/MITLibraries/transmogrifier/assets/1753087/2ff86428-3276-4b78-a2a4-20590412856c">

#### Developer
- [X] All new ENV is documented in README
- [X] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
NO