### PR TITLE
Timx 232 springshare ids

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,18 +34,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0fe7a35cf0041145c8eefebd3ae2ddf41baed62d7c963e5042b8ed8c297f648f",
-                "sha256:e24460d50001b517c6734dcf1c879feb43aa2062d88d9bdbb8703c986cb05941"
+                "sha256:1bae3e6222c7272af44ab4dc456fc4cb7d2d7044489b7a4a08f9cd0fbad6d213",
+                "sha256:8630c2c38c3130e31e1a4182943aee8bc7dd1a1ad9729092b46fdbc8ac045a77"
             ],
-            "version": "==1.28.11"
+            "version": "==1.28.19"
         },
         "botocore": {
             "hashes": [
-                "sha256:b17ff973bb70b02b227928c2abe4992f1cfc46d13aee0228516c8f32572b88c6",
-                "sha256:d3cbffe554c9a1ba2ac6973734c43c21b8e7985a2ac4a4c31a09811b8029445c"
+                "sha256:15f269945f319b0263cde9a61a25f2c9a83f6074b62cddae71edafec4a61e637",
+                "sha256:724f9a1a91f88291f5adc6347705a31e52312c88cddd56e38709215b161e025a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.11"
+            "version": "==1.31.19"
         },
         "certifi": {
             "hashes": [
@@ -187,11 +187,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:6bdb25bd9092478d3a817cb0d01fa99e296aea34d404eac3ca0037faa5c2aa0a",
-                "sha256:dcd88c68aa64dae715311b5ede6502fd684f70d00a7cd4858118f0ba3153a3ae"
+                "sha256:3e17215d8006612e2df02b0e73115eb8376c37e3f586d8436fa41644e605074d",
+                "sha256:a99ee105384788c3f228726a88baf515fe7b5f1d2d0f215a03d194369f158df7"
             ],
             "index": "pypi",
-            "version": "==1.28.1"
+            "version": "==1.29.2"
         },
         "six": {
             "hashes": [
@@ -443,11 +443,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7",
-                "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"
+                "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23",
+                "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"
             ],
             "index": "pypi",
-            "version": "==6.0.0"
+            "version": "==6.1.0"
         },
         "gitdb": {
             "hashes": [
@@ -563,11 +563,11 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687",
-                "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
+                "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20",
+                "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.1"
+            "version": "==0.11.2"
         },
         "pbr": {
             "hashes": [
@@ -579,11 +579,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421",
-                "sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f"
+                "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d",
+                "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.9.1"
+            "version": "==3.10.0"
         },
         "pluggy": {
             "hashes": [
@@ -595,19 +595,19 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053",
-                "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"
+                "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0",
+                "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.10.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.11.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf",
-                "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"
+                "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774",
+                "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.1.0"
         },
         "pygments": {
             "hashes": [
@@ -681,11 +681,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec",
-                "sha256:d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898"
+                "sha256:146a90b3b6b47cac4a73c12866a499e9817426423f57c5a66949c086191a8808",
+                "sha256:fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==13.4.2"
+            "version": "==13.5.2"
         },
         "smmap": {
             "hashes": [

--- a/tests/test_springshare.py
+++ b/tests/test_springshare.py
@@ -12,7 +12,7 @@ RESEARCHDATABASES_FIXTURES_PREFIX = f"{SPRINGSHARE_FIXTURES_PREFIX}/research_dat
 LIBGUIDES_BLANK_OR_MISSING_OPTIONAL_FIELDS_TIMDEX = timdex.TimdexRecord(
     source="LibGuides",
     source_link="https://libguides.mit.edu/materials",
-    timdex_record_id="libguides:materials",
+    timdex_record_id="libguides:guides-175846",
     title="Materials Science & Engineering",
     citation="Materials Science & Engineering. libguides. "
     "https://libguides.mit.edu/materials",
@@ -33,7 +33,7 @@ LIBGUIDES_BLANK_OR_MISSING_OPTIONAL_FIELDS_TIMDEX = timdex.TimdexRecord(
 RESEARCHDATABASES_BLANK_OR_MISSING_OPTIONAL_FIELDS_TIMDEX = timdex.TimdexRecord(
     source="Research Databases",
     source_link="https://libguides.mit.edu/llba",
-    timdex_record_id="researchdatabases:llba",
+    timdex_record_id="researchdatabases:az-65257807",
     title="Linguistics and Language Behavior Abstracts (LLBA)",
     citation="Linguistics and Language Behavior Abstracts (LLBA). researchdatabases. "
     "https://libguides.mit.edu/llba",
@@ -94,7 +94,7 @@ def test_libguide_transform_with_all_fields_transforms_correctly():
     assert next(output_records) == timdex.TimdexRecord(
         source="LibGuides",
         source_link="https://libguides.mit.edu/materials",
-        timdex_record_id="libguides:materials",
+        timdex_record_id="libguides:guides-175846",
         title="Materials Science & Engineering",
         citation="Ye Li. Materials Science & Engineering. MIT Libraries. libguides. "
         "https://libguides.mit.edu/materials",
@@ -154,7 +154,7 @@ def test_research_databases_transform_with_all_fields_transforms_correctly():
     assert next(output_records) == timdex.TimdexRecord(
         source="Research Databases",
         source_link="https://libguides.mit.edu/llba",
-        timdex_record_id="researchdatabases:llba",
+        timdex_record_id="researchdatabases:az-65257807",
         title="Linguistics and Language Behavior Abstracts (LLBA)",
         citation="Linguistics and Language Behavior Abstracts (LLBA). "
         "researchdatabases. https://libguides.mit.edu/llba",

--- a/transmogrifier/sources/ead.py
+++ b/transmogrifier/sources/ead.py
@@ -445,8 +445,8 @@ class Ead(Transformer):
         """
         if skipped_elements is None:
             skipped_elements = []
-        if type(item) == NavigableString and item.strip():
+        if isinstance(item, NavigableString) and item.strip():
             yield str(item.strip())
-        elif type(item) == Tag and item.name not in skipped_elements:
+        elif isinstance(item, Tag) and item.name not in skipped_elements:
             for child in item.children:
                 yield from cls.parse_mixed_value(child, skipped_elements)

--- a/transmogrifier/sources/springshare.py
+++ b/transmogrifier/sources/springshare.py
@@ -80,25 +80,31 @@ class SpringshareOaiDc(OaiDc):
         ]
 
     @classmethod
-    def get_source_record_id(cls, xml: Tag) -> str:
+    def get_source_link(
+        cls, source_base_url: str, source_record_id: str, xml: Tag
+    ) -> str:
         """
-        Get the source record ID from a Springshare OAI DC XML record.
+        Override for default source_link behavior.
 
-        Overrides metaclass get_source_record_id() method.
+        Springshare resources contain the source link in their dc:identifier fields.
+        However, this cannot be reliably split and combined with the source base url,
+        as this either provides poorly formed timdex record ids OR source links that
+        do not work.
 
-        The URL path of the Springshare resource is used as the source record id, which
-        results in a timdex record id like "libguides:materials" or
-        "researchdatabases:llba".  This is preferred over the OAI-PMH identifier, a
-        numeric value, which cannot be used to construct an accessible source link.
+        Example libguides OAI identifier and <dc:identifier>:
+            - oai:libguides.com:guides/175846, https://libguides.mit.edu/materials
+            - oai:libguides.com:guides/175847, https://libguides.mit.edu/c.php?g=175847
 
-        Libguides example:
-            "https://libguides.mit.edu/materials" -> "materials"
+        Example researchdatabases OAI identifier and <dc:identifier>:
+            - oai:libguides.com:az/65257807, https://libguides.mit.edu/llba
 
-        AZ (Research Database) example:
-            "https://libguides.mit.edu/llba" -> "llba"
+        It is preferable to split the OAI header identifier and use this as the TIMDEX
+        record id, but then take the dc:identifier wholesale and use this for the source
+        link.
 
         Args:
-            xml: A BeautifulSoup Tag representing a single Springshare OAI DC XML record.
+            source_base_url: Source base URL.
+            source_record_id: Record identifier for the source record.
+            xml: A BeautifulSoup Tag representing a single XML record.
         """
-
-        return str(xml.find("dc:identifier").string).split("/")[-1]
+        return str(xml.find("dc:identifier").string)

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -118,10 +118,12 @@ class Transformer(object):
         """
         source_record_id = self.get_source_record_id(xml)
         title = self.get_valid_title(source_record_id, xml)
+        source_link = self.get_source_link(self.source_base_url, source_record_id, xml)
+        timdex_record_id = self.get_timdex_record_id(self.source, source_record_id, xml)
         return {
             "source": self.source_name,
-            "source_link": self.source_base_url + source_record_id,
-            "timdex_record_id": f"{self.source}:{source_record_id.replace('/', '-')}",
+            "source_link": source_link,
+            "timdex_record_id": timdex_record_id,
             "title": title,
         }
 
@@ -180,7 +182,7 @@ class Transformer(object):
                 source_record_id,
                 all_titles,
             )
-        if all_titles and type(all_titles[0]) == str:
+        if all_titles and isinstance(all_titles[0], str):
             title = all_titles[0]
         elif all_titles and all_titles[0].string:
             title = all_titles[0].string
@@ -191,3 +193,39 @@ class Transformer(object):
             )
             title = "Title not provided"
         return title
+
+    @classmethod
+    def get_source_link(
+        cls, source_base_url: str, source_record_id: str, xml: Tag
+    ) -> str:
+        """
+        Class method to set the source link for the item.
+
+        May be overridden by source subclasses if needed.
+
+        Default behavior is to concatenate the source base URL + source record id.
+
+        Args:
+            source_base_url: Source base URL.
+            source_record_id: Record identifier for the source record.
+            xml: A BeautifulSoup Tag representing a single XML record.
+        """
+        return source_base_url + source_record_id
+
+    @classmethod
+    def get_timdex_record_id(cls, source: str, source_record_id: str, xml: Tag) -> str:
+        """
+        Class method to set the TIMDEX record id.
+
+        May be overridden by source subclasses if needed.
+
+        Default behavior is to concatenate the source name + source record id.
+
+        Args:
+            source: Source name.
+            source_record_id: Record identifier for the source record.
+            xml: A BeautifulSoup Tag representing a single XML record.
+                - not used by default implementation, but could be useful for subclass
+                overrides
+        """
+        return f"{source}:{source_record_id.replace('/', '-')}"


### PR DESCRIPTION
#### What does this PR do?

This PR adds two new OPTIONAL methods to the base transform:
  * `get_source_link()`
  * `get_timdex_record_id()`

For transformations that require it, this allows for decoupling the logic of constructing the timdex record id from the source link.  This directly supports these new sources, and it's believed will also be helpful for future sources where this tight coupling may not be ideal.

Dependencies are also updated, with slight type check updates for new `flake8` requirements in `ead` transformation.

#### Helpful background context

While analyzing the transformed records from new `libguides` and `researchdatabases` sources, it was found that some timdex record ids were poorly formed, e.g. `libguides:c.php?g=175847`.

The original approach was splitting the `dc:identifier` and using that for the timdex record id and concatenating with the source base url.  However, in a small subset, this resulted in poorly formed ids like the one above.

Given the terse nature of these source records, there is not a meaningful identifier in the record that could serve both the timdex record id _and_ the source link.

#### How can a reviewer manually see the effects of these changes?

For the following fixture (showing subset of fields here):
```xml
<?xml version="1.0" encoding="UTF-8"?>
<records>
  <record>
    <header>
      <identifier>oai:libguides.com:guides/175846</identifier>  <!-- OAI identifier -->
      ...
    </header>
    <metadata>
      <oai_dc:dc>
        ...
        <dc:identifier>https://libguides.mit.edu/materials</dc:identifier>  <!-- DC identifier -->
        ...
      </oai_dc:dc>
    </metadata>
  </record>
</records>
```

Run a `libguides` transformation:
```bash
pipenv run transform -s libguides -i "tests/fixtures/oai_dc/springshare/libguides/libguides_record_all_fields.xml" -o "output/libguides.json"
```

Note the following fields are set:
```python
timdex_record_id="libguides:guides-175846"
source_link="https://libguides.mit.edu/materials",
```

Demonstrating the source link, due to the overriden method, is decoupled from the timdex id.


#### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/TIMX-232

#### Developer
- [X] All new ENV is documented in README
- [X] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
YES