### PR TITLE
Why these changes are being introduced:

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,18 +34,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1bae3e6222c7272af44ab4dc456fc4cb7d2d7044489b7a4a08f9cd0fbad6d213",
-                "sha256:8630c2c38c3130e31e1a4182943aee8bc7dd1a1ad9729092b46fdbc8ac045a77"
+                "sha256:8da9621931291b6c261fdaae465f05737c16519b9667d8463181cb8b88444572",
+                "sha256:a336cf53a6d86ee6d27b2f6d8b78ec9b320209127e5126359881bbd68f33d0b9"
             ],
-            "version": "==1.28.19"
+            "version": "==1.28.27"
         },
         "botocore": {
             "hashes": [
-                "sha256:15f269945f319b0263cde9a61a25f2c9a83f6074b62cddae71edafec4a61e637",
-                "sha256:724f9a1a91f88291f5adc6347705a31e52312c88cddd56e38709215b161e025a"
+                "sha256:13af1588023750c9bc66d202bb5a934c9412a7dc52587532264ab725c42c2c50",
+                "sha256:739d09e13751e3b9b0f341b5ffe5bf8d0452b8769d435c4084ee88739d42b7f7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.19"
+            "version": "==1.31.27"
         },
         "certifi": {
             "hashes": [
@@ -179,11 +179,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346",
-                "sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9"
+                "sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084",
+                "sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.6.1"
+            "version": "==0.6.2"
         },
         "sentry-sdk": {
             "hashes": [
@@ -515,35 +515,31 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:01fd2e9f85622d981fd9063bfaef1aed6e336eaacca00892cd2d82801ab7c042",
-                "sha256:0dde1d180cd84f0624c5dcaaa89c89775550a675aff96b5848de78fb11adabcd",
-                "sha256:141dedfdbfe8a04142881ff30ce6e6653c9685b354876b12e4fe6c78598b45e2",
-                "sha256:16f0db5b641ba159eff72cff08edc3875f2b62b2fa2bc24f68c1e7a4e8232d01",
-                "sha256:190b6bab0302cec4e9e6767d3eb66085aef2a1cc98fe04936d8a42ed2ba77bb7",
-                "sha256:2460a58faeea905aeb1b9b36f5065f2dc9a9c6e4c992a6499a2360c6c74ceca3",
-                "sha256:34a9239d5b3502c17f07fd7c0b2ae6b7dd7d7f6af35fbb5072c6208e76295816",
-                "sha256:43b592511672017f5b1a483527fd2684347fdffc041c9ef53428c8dc530f79a3",
-                "sha256:43d24f6437925ce50139a310a64b2ab048cb2d3694c84c71c3f2a1626d8101dc",
-                "sha256:45d32cec14e7b97af848bddd97d85ea4f0db4d5a149ed9676caa4eb2f7402bb4",
-                "sha256:470c969bb3f9a9efcedbadcd19a74ffb34a25f8e6b0e02dae7c0e71f8372f97b",
-                "sha256:566e72b0cd6598503e48ea610e0052d1b8168e60a46e0bfd34b3acf2d57f96a8",
-                "sha256:5703097c4936bbb9e9bce41478c8d08edd2865e177dc4c52be759f81ee4dd26c",
-                "sha256:7549fbf655e5825d787bbc9ecf6028731973f78088fbca3a1f4145c39ef09462",
-                "sha256:8207b7105829eca6f3d774f64a904190bb2231de91b8b186d21ffd98005f14a7",
-                "sha256:8c4d8e89aa7de683e2056a581ce63c46a0c41e31bd2b6d34144e2c80f5ea53dc",
-                "sha256:98324ec3ecf12296e6422939e54763faedbfcc502ea4a4c38502082711867258",
-                "sha256:9bbcd9ab8ea1f2e1c8031c21445b511442cc45c89951e49bbf852cbb70755b1b",
-                "sha256:9d40652cc4fe33871ad3338581dca3297ff5f2213d0df345bcfbde5162abf0c9",
-                "sha256:a2746d69a8196698146a3dbe29104f9eb6a2a4d8a27878d92169a6c0b74435b6",
-                "sha256:ae704dcfaa180ff7c4cfbad23e74321a2b774f92ca77fd94ce1049175a21c97f",
-                "sha256:bfdca17c36ae01a21274a3c387a63aa1aafe72bff976522886869ef131b937f1",
-                "sha256:c482e1246726616088532b5e964e39765b6d1520791348e6c9dc3af25b233828",
-                "sha256:ca637024ca67ab24a7fd6f65d280572c3794665eaf5edcc7e90a866544076878",
-                "sha256:e02d700ec8d9b1859790c0475df4e4092c7bf3272a4fd2c9f33d87fac4427b8f",
-                "sha256:e5952d2d18b79f7dc25e62e014fe5a23eb1a3d2bc66318df8988a01b1a037c5b"
+                "sha256:1fe816e26e676c1311b9e04fd576543b873576d39439f7c24c8e5c7728391ecf",
+                "sha256:2c9d570f53908cbea326ad8f96028a673b814d9dca7515bf71d95fa662c3eb6f",
+                "sha256:35b13335c6c46a386577a51f3d38b2b5d14aa619e9633bb756bd77205e4bd09f",
+                "sha256:372fd97293ed0076d52695849f59acbbb8461c4ab447858cdaeaf734a396d823",
+                "sha256:42170e68adb1603ccdc55a30068f72bcfcde2ce650188e4c1b2a93018b826735",
+                "sha256:69b32d0dedd211b80f1b7435644e1ef83033a2af2ac65adcdc87c38db68a86be",
+                "sha256:725b57a19b7408ef66a0fd9db59b5d3e528922250fb56e50bded27fea9ff28f0",
+                "sha256:769ddb6bfe55c2bd9c7d6d7020885a5ea14289619db7ee650e06b1ef0852c6f4",
+                "sha256:79c520aa24f21852206b5ff2cf746dc13020113aa73fa55af504635a96e62718",
+                "sha256:84cf9f7d8a8a22bb6a36444480f4cbf089c917a4179fbf7eea003ea931944a7f",
+                "sha256:9166186c498170e1ff478a7f540846b2169243feb95bc228d39a67a1a450cdc6",
+                "sha256:a2500ad063413bc873ae102cf655bf49889e0763b260a3a7cf544a0cbbf7e70a",
+                "sha256:a551ed0fc02455fe2c1fb0145160df8336b90ab80224739627b15ebe2b45e9dc",
+                "sha256:ad3109bec37cc33654de8db30fe8ff3a1bb57ea65144167d68185e6dced9868d",
+                "sha256:b4ea3a0241cb005b0ccdbd318fb99619b21ae51bcf1660b95fc22e0e7d3ba4a1",
+                "sha256:c36011320e452eb30bec38b9fd3ba20569dc9545d7d4540d967f3ea1fab9c374",
+                "sha256:c8a7444d6fcac7e2585b10abb91ad900a576da7af8f5cffffbff6065d9115813",
+                "sha256:cbf18f8db7e5f060d61c91e334d3b96d6bb624ddc9ee8a1cde407b737acbca2c",
+                "sha256:d145b81a8214687cfc1f85c03663a5bbe736777410e5580e54d526e7e904f564",
+                "sha256:eec5c927aa4b3e8b4781840f1550079969926d0a22ce38075f6cfcf4b13e3eb4",
+                "sha256:f3460f34b3839b9bc84ee3ed65076eb827cd99ed13ed08d723f9083cada4a212",
+                "sha256:f3940cf5845b2512b3ab95463198b0cdf87975dfd17fdcc6ce9709a9abe09e69"
             ],
             "index": "pypi",
-            "version": "==1.4.1"
+            "version": "==1.5.0"
         },
         "mypy-extensions": {
             "hashes": [
@@ -611,11 +607,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c",
-                "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"
+                "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692",
+                "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.15.1"
+            "version": "==2.16.1"
         },
         "pytest": {
             "hashes": [

--- a/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
@@ -59,6 +59,9 @@
                         <unitid>
                             <emph>Data enclosed in subelement</emph>
                         </unitid>
+                        <unitid type="aspace_uri">
+                            <emph>unitid-that-should-not-be-identifier</emph>
+                        </unitid>
                         <abstract>
                             <emph>Data enclosed in subelement</emph>
                         </abstract>

--- a/tests/test_ead.py
+++ b/tests/test_ead.py
@@ -526,6 +526,15 @@ def test_ead_record_invalid_date_and_date_range_are_omitted(caplog):
     ) in caplog.text
 
 
+def test_ead_record_correct_identifiers_from_multiple_unitid(caplog):
+    ead_xml_records = parse_xml_records(
+        "tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml"
+    )
+    output_record = next(Ead("aspace", ead_xml_records))
+    for identifier in output_record.identifiers:
+        assert identifier.value != "unitid-that-should-not-be-identifier"
+
+
 def test_ead_record_with_missing_optional_fields_transforms_correctly():
     ead_xml_records = parse_xml_records(
         "tests/fixtures/ead/ead_record_missing_optional_fields.xml"

--- a/transmogrifier/sources/ead.py
+++ b/transmogrifier/sources/ead.py
@@ -152,6 +152,8 @@ class Ead(Transformer):
         for id_element in collection_description_did.find_all(
             "unitid", recursive=False
         ):
+            if id_element.get("type") == "aspace_uri":
+                continue
             if id_value := self.create_string_from_mixed_value(
                 id_element,
                 " ",


### PR DESCRIPTION
#### What does this PR do?

For ASpace records, any `<unitid type="aspace_uri">` elements are skipped for consideration as TIMDEX record `identifiers`.  

#### Helpful background context

It was discovered that some ASpace records after transformation contained multiple identifiers, of the same type, which was throwing errors in Bento.  It looks as though ASpace records may have changed slightly and are exposing a new string for the <unitid> element, which is the same as the OAI record identifier.

Before:
<img width="959" alt="Screenshot 2023-08-16 at 11 06 56 AM" src="https://github.com/MITLibraries/transmogrifier/assets/1753087/cec8d858-1968-40be-a6fb-c70db9f6ea25">

After:
<img width="863" alt="Screenshot 2023-08-16 at 11 05 54 AM" src="https://github.com/MITLibraries/transmogrifier/assets/1753087/5ce78c17-8e88-4ef7-8bd0-2f1c12bc83af">

#### How can a reviewer manually see the effects of these changes?

Run the following transform:
```bash
pipenv run transform -s aspace -i tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml -o output/aspace-ead-single-identifier.json
```
- observe that `identifiers` property only has a single value, despite two `<unitid>` elements present under `<archdesc level="collection">`

#### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/TIMX-234

#### Developer
- [X] All new ENV is documented in README
- [X] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
YES