### PR TITLE
Timx 241 springshare oai dates

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,18 +34,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2761f3249fe25c3ec1a8cd6b95fca2317747503e6f1d127daf6a3d2cdeb25680",
-                "sha256:dc6d72470f6d8926b8cdc10ee7708d7ccdd36d6313c7aa298bc1cf6bedb8921e"
+                "sha256:2ccbea42fe4cbd22a8ba1e90a37ac65f05c1932e63432e429fb7158d8255bbc0",
+                "sha256:4713a4e69120db5f358f4d378459fb4ea04be98664a0908088f6e04ab49d2583"
             ],
-            "version": "==1.28.31"
+            "version": "==1.28.34"
         },
         "botocore": {
             "hashes": [
-                "sha256:1eef14ae98e8662e43f7cf6d993c732793def02644e2d489c5171d3b9269e900",
-                "sha256:950a49c5286fe1f6d72cfbe2910b9ddbdfbb907975ddc41cf38ac9709b4d1291"
+                "sha256:23ba9e3a8b4c0e5966bbe2db62edb27f61e16b846f153f22aefda7b3c05c7942",
+                "sha256:456ef8eb458db35b8643eb10e652ed50750d13e5af431593471b2c705c34b5db"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.31.31"
+            "version": "==1.31.34"
         },
         "certifi": {
             "hashes": [

--- a/tests/test_oai_dc.py
+++ b/tests/test_oai_dc.py
@@ -74,5 +74,5 @@ def test_oaidc_generic_date():
     transformer_instance = OaiDc("libguides", input_records)
     xml = next(transformer_instance.input_records)
     assert transformer_instance.get_dates("test_source_record_id", xml) == [
-        timdex.Date(kind=None, note=None, range=None, value="2008-06-19T17:55:27")
+        timdex.Date(kind="Unknown", note=None, range=None, value="2008-06-19T17:55:27")
     ]

--- a/tests/test_springshare.py
+++ b/tests/test_springshare.py
@@ -60,7 +60,9 @@ def test_springshare_get_dates_valid():
     for xml in transformer_instance.input_records:
         date_field_value = transformer_instance.get_dates("test_get_dates", xml)
         assert date_field_value == [
-            timdex.Date(kind=None, note=None, range=None, value="2000-01-01T00:00:00")
+            timdex.Date(
+                kind="Created", note=None, range=None, value="2000-01-01T00:00:00"
+            )
         ]
 
 
@@ -106,7 +108,7 @@ def test_libguide_transform_with_all_fields_transforms_correctly():
             )
         ],
         dates=[
-            timdex.Date(value="2008-06-19T17:55:27"),
+            timdex.Date(value="2008-06-19T17:55:27", kind="Created"),
         ],
         format="electronic resource",
         identifiers=[
@@ -160,7 +162,7 @@ def test_research_databases_transform_with_all_fields_transforms_correctly():
         "researchdatabases. https://libguides.mit.edu/llba",
         content_type=["researchdatabases"],
         dates=[
-            timdex.Date(value="2022-01-28T22:15:37"),
+            timdex.Date(value="2022-01-28T22:15:37", kind="Created"),
         ],
         format="electronic resource",
         identifiers=[

--- a/transmogrifier/sources/oaidc.py
+++ b/transmogrifier/sources/oaidc.py
@@ -137,7 +137,7 @@ class OaiDc(Transformer):
                     date_str,
                     source_record_id,
                 ):
-                    dates.append(timdex.Date(value=date_str))
+                    dates.append(timdex.Date(value=date_str, kind="Unknown"))
         return dates or None
 
     def get_links(self, source_record_id: str, xml: Tag) -> Optional[List[timdex.Link]]:

--- a/transmogrifier/sources/springshare.py
+++ b/transmogrifier/sources/springshare.py
@@ -51,7 +51,7 @@ class SpringshareOaiDc(OaiDc):
                 date_iso_str,
                 source_record_id,
             ):
-                dates.append(timdex.Date(value=date_iso_str, kind=None))
+                dates.append(timdex.Date(value=date_iso_str, kind="Created"))
         return dates or None
 
     def get_links(self, source_record_id: str, xml: Tag) -> Optional[List[timdex.Link]]:


### PR DESCRIPTION
#### What does this PR do?

Sets `date.kind` property for Springshare and generic OAI-DC transformers.

#### Helpful background context
It was discovered that setting `date.kind = None` was throwing errors in GraphQL, which prevented the `date` field from coming through:

```json
{
  "data": {
    "search": {
      "hits": 1,
      "records": [
        {
          "timdexRecordId": "libguides:guides-1336858",
          "title": "Affirmative Action",
          "source": "LibGuides",
          "dates": null
        }
      ]
    }
  },
  "errors": [
    {
      "message": "Cannot return null for non-nullable field Date.kind"  #<---------------
    }
  ]
}
```

While the Springshare OAI records don't have any additional metadata about the `<dc:date>` fields, it was determined that they must be "Created" as they don't change across modifications to the resource.

#### How can a reviewer manually see the effects of these changes?

Run libguides transformation:
```shell
pipenv run transform -s libguides -i "tests/fixtures/oai_dc/springshare/libguides/libguides_record_all_fields.xml" -o "output/libguides.json"
```

Note `kind="Created"` where dates present:
```json
"dates": [
        {
            "kind": "Created",
            "value": "2008-06-19T17:55:27"
        }
    ],
```

#### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/TIMX-241

#### Developer
- [X] All new ENV is documented in README
- [X] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
YES