### PR TITLE
Gdt 83 jsontransformer

### DIFF
--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -7,14 +7,6 @@ from transmogrifier.sources.datacite import Datacite
 from transmogrifier.sources.transformer import Transformer, XmlTransformer
 
 
-def test_transformer_initializes_with_expected_attributes(oai_pmh_records):
-    transformer = Transformer("cool-repo", oai_pmh_records)
-    assert transformer.source == "cool-repo"
-    assert transformer.source_base_url == "https://example.com/"
-    assert transformer.source_name == "A Cool Repository"
-    assert transformer.source_records == oai_pmh_records
-
-
 def test_transformer_get_transformer_returns_correct_class_name():
     assert Transformer.get_transformer("jpal") == Datacite
 
@@ -136,7 +128,6 @@ def test_xmltransformer_get_valid_title_with_title_field_multiple_logs_warning(c
     )
     assert (
         "Record doi:10.7910/DVN/19PPE7 has multiple titles. Using the first title from "
-        "the following titles found: [<title>The Impact of Maternal Literacy and "
-        "Participation Programs</title>, <title>Additional Title</title>]"
-        in caplog.text
+        "the following titles found: ['The Impact of Maternal Literacy and "
+        "Participation Programs', 'Additional Title']" in caplog.text
     )

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -57,6 +57,31 @@ def test_xmltransformer_iterates_successfully_if_get_optional_fields_returns_non
         assert len(output_records.deleted_records) == 1
 
 
+def test_xmltransformer__write_output_files_writes_timdex_records_and_deleted_files(
+    tmp_path, oai_pmh_records
+):
+    output_file = str(tmp_path / "output_file.json")
+    transformer = XmlTransformer("cool-repo", oai_pmh_records)
+    transformer._write_output_files(output_file)
+    output_files = list(tmp_path.iterdir())
+    assert len(output_files) == 2
+    assert output_files[0].name == "output_file.json"
+    assert output_files[1].name == "output_file.txt"
+
+
+def test_xmltransformer__write_output_files_no_deleted_records_file_if_not_needed(
+    tmp_path,
+):
+    output_file = str(tmp_path / "output_file.json")
+    datacite_records = XmlTransformer.parse_source_file(
+        "tests/fixtures/datacite/datacite_records.xml"
+    )
+    transformer = XmlTransformer("cool-repo", datacite_records)
+    transformer._write_output_files(output_file)
+    assert len(list(tmp_path.iterdir())) == 1
+    assert next(tmp_path.iterdir()).name == "output_file.json"
+
+
 def test_xmltransformer_parse_source_file_returns_record_iterator():
     records = XmlTransformer.parse_source_file(
         "tests/fixtures/datacite/datacite_records.xml"

--- a/transmogrifier/cli.py
+++ b/transmogrifier/cli.py
@@ -5,7 +5,6 @@ from time import perf_counter
 import click
 
 from transmogrifier.config import SOURCES, configure_logger, configure_sentry
-from transmogrifier.helpers import write_deleted_records_to_file
 from transmogrifier.sources.transformer import Transformer
 
 logger = logging.getLogger(__name__)
@@ -42,14 +41,7 @@ def main(source, input_file, output_file, verbose):
     logger.info("Running transform for source %s", source)
 
     transformer = Transformer.load(source, input_file)
-    transformer.write_timdex_records_to_json(output_file)
-    if transformer.processed_record_count == 0:
-        raise ValueError("No records processed from input file, needs investigation")
-    if deleted_records := transformer.deleted_records:
-        deleted_output_file = output_file.replace("index", "delete").replace(
-            "json", "txt"
-        )
-        write_deleted_records_to_file(deleted_records, deleted_output_file)
+    transformer._write_output_files(output_file)
     logger.info(
         (
             "Completed transform, total records processed: %d, "

--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -2,8 +2,6 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from smart_open import open
-
 from transmogrifier.config import DATE_FORMATS
 
 logger = logging.getLogger(__name__)
@@ -138,12 +136,6 @@ def validate_date_range(
             end_date,
         )
         return False
-
-
-def write_deleted_records_to_file(deleted_records: list[str], output_file_path: str):
-    with open(output_file_path, "w") as file:
-        for record_id in deleted_records:
-            file.write(f"{record_id}\n")
 
 
 class DeletedRecord(Exception):

--- a/transmogrifier/sources/datacite.py
+++ b/transmogrifier/sources/datacite.py
@@ -40,7 +40,7 @@ class Datacite(XmlTransformer):
         for index, title in enumerate(self.get_main_titles(xml)):
             if index > 0:
                 fields.setdefault("alternate_titles", []).append(
-                    timdex.AlternateTitle(value=title.string)
+                    timdex.AlternateTitle(value=title)
                 )
 
         # content_type
@@ -309,7 +309,7 @@ class Datacite(XmlTransformer):
         return fields
 
     @classmethod
-    def get_main_titles(cls, xml: Tag) -> list[Tag]:
+    def get_main_titles(cls, xml: Tag) -> list[str]:
         """
         Retrieve main title(s) from a Datacite XML record.
 
@@ -320,7 +320,7 @@ class Datacite(XmlTransformer):
                 oai_datacite XML.
         """
         return [
-            t
+            t.string
             for t in xml.metadata.find_all("title", string=True)
             if not t.get("titleType")
         ]

--- a/transmogrifier/sources/dspace_dim.py
+++ b/transmogrifier/sources/dspace_dim.py
@@ -42,7 +42,7 @@ class DspaceDim(XmlTransformer):
         for index, title in enumerate(self.get_main_titles(xml)):
             if index > 0:
                 fields.setdefault("alternate_titles", []).append(
-                    timdex.AlternateTitle(value=title.string)
+                    timdex.AlternateTitle(value=title)
                 )
 
         # citation
@@ -280,7 +280,7 @@ class DspaceDim(XmlTransformer):
         ] or None
 
     @classmethod
-    def get_main_titles(cls, xml: Tag) -> list[Tag]:
+    def get_main_titles(cls, xml: Tag) -> list[str]:
         """
         Retrieve main title(s) from a DSpace DIM XML record.
 
@@ -290,8 +290,8 @@ class DspaceDim(XmlTransformer):
             xml: A BeautifulSoup Tag representing a single DSpace DIM XML record.
         """
         return [
-            t
-            for t in xml.find_all("dim:field", element="title")
+            t.string
+            for t in xml.find_all("dim:field", element="title", string=True)
             if "qualifier" not in t.attrs
         ]
 

--- a/transmogrifier/sources/dspace_mets.py
+++ b/transmogrifier/sources/dspace_mets.py
@@ -40,7 +40,7 @@ class DspaceMets(XmlTransformer):
         for index, title in enumerate(self.get_main_titles(xml)):
             if index > 0:
                 fields.setdefault("alternate_titles", []).append(
-                    timdex.AlternateTitle(value=title.string)
+                    timdex.AlternateTitle(value=title)
                 )
 
         # call_numbers: relevant field in DSpace (dc.subject.classification) is not
@@ -191,7 +191,7 @@ class DspaceMets(XmlTransformer):
         return fields
 
     @classmethod
-    def get_main_titles(cls, xml: Tag) -> list[Tag]:
+    def get_main_titles(cls, xml: Tag) -> list[str]:
         """
         Retrieve main title(s) from a DSpace METS XML record.
 
@@ -200,7 +200,11 @@ class DspaceMets(XmlTransformer):
         Args:
             xml: A BeautifulSoup Tag representing a single DSpace METS XML record.
         """
-        return [t for t in xml.find_all("mods:title", string=True) if not t.get("type")]
+        return [
+            t.string
+            for t in xml.find_all("mods:title", string=True)
+            if not t.get("type")
+        ]
 
     @classmethod
     def get_source_record_id(cls, xml: Tag) -> str:

--- a/transmogrifier/sources/oaidc.py
+++ b/transmogrifier/sources/oaidc.py
@@ -153,7 +153,7 @@ class OaiDc(XmlTransformer):
         return None
 
     @classmethod
-    def get_main_titles(cls, xml: Tag) -> list[Tag]:
+    def get_main_titles(cls, xml: Tag) -> list[str]:
         """
         Retrieve main title(s) from a generic OAI DC XML record.
 
@@ -162,7 +162,7 @@ class OaiDc(XmlTransformer):
         Args:
             xml: A BeautifulSoup Tag representing a single OAI DC XML record.
         """
-        return [t for t in xml.find_all("dc:title")]
+        return [t.string for t in xml.find_all("dc:title", string=True)]
 
     @classmethod
     def get_source_record_id(cls, xml: Tag) -> str:


### PR DESCRIPTION
#### Helpful background context
Additional refactoring was needed on the `XmlTransformer` class to provide a proper example for the `JsonTransformer` class. Given the incomplete nature of `JsonTransformer` which has several `abstractmethod`s that need to be defined by source transforms, proper testing won't be possible until a source transform is derived from `JsonTransformer`


#### How can a reviewer manually see the effects of these changes?
Run a transform on a test fixture to ensure that the base class and associated refactor hasn't broken the application

```
pipenv run transform -i tests/fixtures/ead/ead_record_all_fields.xml -o output/aspace-records.json -s aspace
```

#### What are the relevant tickets?
* https://mitlibraries.atlassian.net/browse/GDT-83

#### Developer
- [x] All new ENV is documented in README
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
NO