### PR TITLE
GDT-54 Address mismatches with OpenSearch mapping

### DIFF
--- a/tests/fixtures/aardvark_records.jsonl
+++ b/tests/fixtures/aardvark_records.jsonl
@@ -1,2 +1,2 @@
-{"dct_accessRights_s": "Access rights", "dct_references_s": "", "dct_title_s": "Test title 1", "gbl_mdModified_dt": "", "gbl_mdVersion_s": "", "gbl_resourceClass_sm": "", "id": "mit:123", "locn_geometry": ""}
-{"dct_accessRights_s": "Access rights", "dct_references_s": "", "dct_title_s": "Test title 2", "gbl_mdModified_dt": "", "gbl_mdVersion_s": "", "gbl_resourceClass_sm": "", "id": "ogm:456", "locn_geometry": ""}
+{"dct_accessRights_s": "Access rights", "dct_references_s": "", "dct_title_s": "Test title 1", "gbl_mdModified_dt": "", "gbl_mdVersion_s": "", "gbl_resourceClass_sm": "", "id": "mit:123", "locn_geometry": "ENVELOPE(-111.1, -104.0, 45.0, 40.9)"}
+{"dct_accessRights_s": "Access rights", "dct_references_s": "", "dct_title_s": "Test title 2", "gbl_mdModified_dt": "", "gbl_mdVersion_s": "", "gbl_resourceClass_sm": "", "id": "ogm:456", "locn_geometry": "ENVELOPE(-111.1, -104.0, 45.0, 40.9)"}

--- a/tests/sources/json/test_aardvark.py
+++ b/tests/sources/json/test_aardvark.py
@@ -75,6 +75,7 @@ def test_aardvark_get_dates_success(aardvark_record_all_fields):
         timdex.Date(kind="Coverage", value="1945"),
         timdex.Date(kind="Coverage", value="1946"),
         timdex.Date(
+            kind="Coverage",
             range=timdex.Date_Range(gte="1943", lte="1946"),
         ),
     ]
@@ -97,7 +98,7 @@ def test_parse_solr_date_range_invalid_date_range_string_raises_error():
 
 def test_aardvark_get_identifiers_success(aardvark_record_all_fields):
     assert MITAardvark.get_identifiers(next(aardvark_record_all_fields)) == [
-        timdex.Identifier(value="abc123")
+        timdex.Identifier(value="abc123", kind="Not specified")
     ]
 
 
@@ -129,11 +130,11 @@ def test_aardvark_get_links_logs_warning_for_invalid_json(caplog):
     )
 
 
-def test_aardvark_get_locations_success(aardvark_record_all_fields):
-    assert MITAardvark.get_locations(next(aardvark_record_all_fields), "123") == [
-        timdex.Location(kind="Bounding Box", geodata=[-111.1, -104.0, 45.0, 40.9]),
-        timdex.Location(kind="Geometry", geodata=[-111.1, -104.0, 45.0, 40.9]),
-    ]
+def test_aardvark_get_locations_success(caplog, aardvark_record_all_fields):
+    caplog.set_level("DEBUG")
+    assert "Geometry field 'dcat_bbox' found, but currently not mapped."
+    assert "Geometry field 'locn_geometry' found, but currently not mapped."
+    assert MITAardvark.get_locations(next(aardvark_record_all_fields), "123") == []
 
 
 def test_aardvark_get_notes_success(aardvark_record_all_fields):


### PR DESCRIPTION
#### Helpful background context
After an MITAardvark transformation was mostly completed, a couple of small bugs were discovered when attempting to index the transformed TIMDEX records into OpenSearch.  This commit adddresses those bugs, both full fixes and workarounds, to allow continued pipeline testing and improvements to the MITAardvark transformation.

How this addresses that need:
* adds `kind` property to Dates and Identifiers
* uses `locations.value` instead of `locations.geodata`

#### How can a reviewer manually see the effects of these changes?
Not readily testable as the StepFunction pipeline is not fully formed to attempt indexing of these documents.  But, these changes have been confirmed via a local solution that applied these updates to the transformation process, then successfully indexed documents into OpenSearch.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-54

#### Developer
- [X] All new ENV is documented in README
- [X] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?
YES | NO