### PR TITLE
Map Aardvark.dct_spatial_sm to Locations@kind="Place Name"

### DIFF
--- a/tests/sources/test_transformer.py
+++ b/tests/sources/test_transformer.py
@@ -46,6 +46,30 @@ def test_create_dates_and_locations_from_publishers_success():
     }
 
 
+def test_create_locations_from_spatial_subjects():
+    fields = {
+        "subjects": [
+            timdex.Subject(
+                value=["Some city, Some country"], kind="Dublin Core; Spatial"
+            ),
+            timdex.Subject(value=["City 1", "City 2"], kind="Dublin Core; Spatial"),
+        ]
+    }
+    assert Transformer.create_locations_from_spatial_subjects(fields) == {
+        "subjects": [
+            timdex.Subject(
+                value=["Some city, Some country"], kind="Dublin Core; Spatial"
+            ),
+            timdex.Subject(value=["City 1", "City 2"], kind="Dublin Core; Spatial"),
+        ],
+        "locations": [
+            timdex.Location(value="Some city, Some country", kind="Place Name"),
+            timdex.Location(value="City 1", kind="Place Name"),
+            timdex.Location(value="City 2", kind="Place Name"),
+        ],
+    }
+
+
 def test_xmltransformer_initializes_with_expected_attributes(oai_pmh_records):
     transformer = XMLTransformer("cool-repo", oai_pmh_records)
     assert transformer.source == "cool-repo"

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -402,22 +402,16 @@ class Transformer(ABC):
         Args:
            fields: A dict of fields representing a TIMDEX record.
         """
-        if not (subjects := fields.get("subjects")):
+        if fields.get("subjects") is None:
             return fields
 
-        if not (
-            spatial_subjects := list(
-                filter(
-                    lambda subject: subject.kind == "Dublin Core; Spatial", subjects  # type: ignore[arg-type]
-                )
-            )
-        ):
-            return fields
+        spatial_subjects = [
+            subject
+            for subject in fields.get("subjects", [])  # defaults to empty list
+            if subject.kind == "Dublin Core; Spatial" and subject.value is not None
+        ]
 
         for subject in spatial_subjects:
-            if not subject.value:
-                continue
-
             for place_name in subject.value:
                 subject_location = timdex.Location(value=place_name, kind="Place Name")
                 if subject_location not in fields.setdefault("locations", []):


### PR DESCRIPTION
### Purpose and background context
Map `Aardvark.dct_spatial_sm` to `Locations@kind="Place Name"` to support the use of place names
for location-based searching for GeoData. 

**Note:** `MITAardvark` is the only source transformer that writes `Subject@kind="Dublin Core; Spatial"` (i.e., what `Aardvark.dct_spatial_sm` currently maps to), so the updated mapping is only applied to this transformer.

### How can a reviewer manually see the effects of these changes?

1. Temporarily set AWS credentials for `TimdexManagers` for `Dev1` in your terminal.
2. Transform `gismit` records
   * Run the following command from your local clone of `transmogrifier`:
      ```
      pipenv run transform -i s3://timdex-extract-dev-222053980223/gismit/gismit-2024-03-11-full-extracted-records-to-index.jsonl -o output/output_gismit.json -s gismit -v
      ```
   * View `output/output_gismit.json`. Lines 67-88 should read:
      <img width="711" alt="image" src="https://github.com/MITLibraries/transmogrifier/assets/29102054/1b293322-f644-4138-bef5-549e2aeb97bd">

  
3. Transform `gisogm` records (a partial run, at least!)
   * Run the following command from your local clone of `transmogrifier`:
      ```
      pipenv run transform -i s3://timdex-extract-dev-222053980223/gisogm/gisogm-2024-03-01-full-extracted-records-to-index.jsonl -o output/output_gisogm.json -s gisogm -v
      ```
   * View `output/output_gisogm.json`. Lines 49-66 should read:
     <img width="706" alt="image" src="https://github.com/MITLibraries/transmogrifier/assets/29102054/2d2884d8-8501-4321-a819-e1ab01b88628">

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/GDT-217

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

