### PR TITLE
Update post-transform methods to handle None values

### DIFF
--- a/tests/sources/test_transformer.py
+++ b/tests/sources/test_transformer.py
@@ -46,7 +46,24 @@ def test_create_dates_and_locations_from_publishers_success():
     }
 
 
-def test_create_locations_from_spatial_subjects():
+def test_create_dates_and_locations_from_publishers_when_fields_are_none_success():
+    fields = {
+        "publishers": [
+            timdex.Publisher(name="Publisher", date="Date", location="Location")
+        ],
+        "dates": None,
+        "locations": None,
+    }
+    assert Transformer.create_dates_and_locations_from_publishers(fields) == {
+        "publishers": [
+            timdex.Publisher(name="Publisher", date="Date", location="Location")
+        ],
+        "dates": [timdex.Date(kind="Publication date", value="Date")],
+        "locations": [timdex.Location(value="Location", kind="Place of Publication")],
+    }
+
+
+def test_create_locations_from_spatial_subjects_success():
     fields = {
         "subjects": [
             timdex.Subject(
@@ -54,6 +71,31 @@ def test_create_locations_from_spatial_subjects():
             ),
             timdex.Subject(value=["City 1", "City 2"], kind="Dublin Core; Spatial"),
         ]
+    }
+    assert Transformer.create_locations_from_spatial_subjects(fields) == {
+        "subjects": [
+            timdex.Subject(
+                value=["Some city, Some country"], kind="Dublin Core; Spatial"
+            ),
+            timdex.Subject(value=["City 1", "City 2"], kind="Dublin Core; Spatial"),
+        ],
+        "locations": [
+            timdex.Location(value="Some city, Some country", kind="Place Name"),
+            timdex.Location(value="City 1", kind="Place Name"),
+            timdex.Location(value="City 2", kind="Place Name"),
+        ],
+    }
+
+
+def test_create_locations_from_spatial_subjects_when_field_is_none_success():
+    fields = {
+        "subjects": [
+            timdex.Subject(
+                value=["Some city, Some country"], kind="Dublin Core; Spatial"
+            ),
+            timdex.Subject(value=["City 1", "City 2"], kind="Dublin Core; Spatial"),
+        ],
+        "locations": None,
     }
     assert Transformer.create_locations_from_spatial_subjects(fields) == {
         "subjects": [

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -384,13 +384,17 @@ class Transformer(ABC):
                 publisher_date = timdex.Date(
                     kind="Publication date", value=publisher.date
                 )
-                if publisher_date not in fields.setdefault("dates", []):
+                if fields.get("dates") is None:
+                    fields["dates"] = []
+                if publisher_date not in fields["dates"]:
                     fields["dates"].append(publisher_date)
             if publisher.location:
                 publisher_location = timdex.Location(
                     kind="Place of Publication", value=publisher.location
                 )
-                if publisher_location not in fields.setdefault("locations", []):
+                if fields.get("locations") is None:
+                    fields["locations"] = []
+                if publisher_location not in fields["locations"]:
                     fields["locations"].append(publisher_location)
         return fields
 
@@ -414,6 +418,8 @@ class Transformer(ABC):
         for subject in spatial_subjects:
             for place_name in subject.value:
                 subject_location = timdex.Location(value=place_name, kind="Place Name")
-                if subject_location not in fields.setdefault("locations", []):
+                if fields.get("locations") is None:
+                    fields["locations"] = []
+                if subject_location not in fields["locations"]:
                     fields["locations"].append(subject_location)
         return fields


### PR DESCRIPTION
### Purpose and background context

An error was encountered when trying to run the latest updates to the transformer against the full `gisogm` source:
```
File "/Users/jcuerdo/Documents/repos/transmogrifier/transmogrifier/sources/transformer.py", line 256, in _transform
    fields = self.create_locations_from_spatial_subjects(fields)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcuerdo/Documents/repos/transmogrifier/transmogrifier/sources/transformer.py", line 417, in create_locations_from_spatial_subjects
    if subject_location not in fields.setdefault("locations", []):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```
When a field method returns `None` values (resulting from `or None` statements), the `fields` dictionary will be populated with a key-value pair formatted as `<field_name>: None`. The `fields.setdefault(<field_name>, [])` method will  only set values to an empty list **if** the key is not present. The solution proposed is to have post-transform methods (a) check if the value for a field in `fields` is `None` and (b) if `None`, set the value to an empty list.

### How can a reviewer manually see the effects of these changes?

1. Temporarily set AWS credentials for `TimdexManagers` for `Dev1` in your terminal.

2. Run transform on full set of `gisogm` records:
   * Run the following command from your local clone of `transmogrifier`:
      ```
      pipenv run transform -i s3://timdex-extract-dev-222053980223/gisogm/gisogm-2024-03-01-full-extracted-records-to-index.jsonl -o output/output_gisogm.json -s gisogm -v
      ```

3. Verify completion without error!

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/GDT-217
- https://mitlibraries.atlassian.net/browse/GDT-210

### Developer
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

