### PR TITLE
Update exception handling

### DIFF
--- a/transmogrifier/exceptions.py
+++ b/transmogrifier/exceptions.py
@@ -16,6 +16,6 @@ class SkippedRecordEvent(Exception):  # noqa: N818
         source_record_id: The ID for the source record.
     """
 
-    def __init__(self, source_record_id: str | None, message: str) -> None:
+    def __init__(self, message: str | None = None, source_record_id: str | None = None):
+        super().__init__(message)
         self.source_record_id = source_record_id
-        self.message = message

--- a/transmogrifier/exceptions.py
+++ b/transmogrifier/exceptions.py
@@ -1,0 +1,20 @@
+class DeletedRecordEvent(Exception):  # noqa: N818
+    """Exception raised for records with a deleted status.
+
+    Attributes:
+        timdex_record_id: The TIMDEX record ID (not the source record ID) for the record.
+    """
+
+    def __init__(self, timdex_record_id: str) -> None:
+        self.timdex_record_id = timdex_record_id
+
+
+class SkippedRecordEvent(Exception):  # noqa: N818
+    """Exception raised for records that should be skipped.
+
+    Attributes:
+        source_record_id: The ID for the source record.
+    """
+
+    def __init__(self, source_record_id: str) -> None:
+        self.source_record_id = source_record_id

--- a/transmogrifier/exceptions.py
+++ b/transmogrifier/exceptions.py
@@ -16,5 +16,6 @@ class SkippedRecordEvent(Exception):  # noqa: N818
         source_record_id: The ID for the source record.
     """
 
-    def __init__(self, source_record_id: str) -> None:
+    def __init__(self, source_record_id: str | None, message: str) -> None:
         self.source_record_id = source_record_id
+        self.message = message

--- a/transmogrifier/helpers.py
+++ b/transmogrifier/helpers.py
@@ -132,15 +132,3 @@ def validate_date_range(
         end_date,
     )
     return False
-
-
-class DeletedRecordEvent(Exception):  # noqa: N818
-    """Exception raised for records with a deleted status.
-
-    Attributes:
-        timdex_record_id: The TIMDEX record ID (not the source record ID) for the record
-
-    """
-
-    def __init__(self, timdex_record_id: str) -> None:
-        self.timdex_record_id = timdex_record_id

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -72,11 +72,11 @@ class Transformer(ABC):
             except SkippedRecordEvent:
                 self.skipped_record_count += 1
                 continue
-            if record:
-                self.transformed_record_count += 1
-                return record
-            self.skipped_record_count += 1
-            continue
+            if not record:
+                self.skipped_record_count += 1
+                continue
+            self.transformed_record_count += 1
+            return record
 
     @final
     def transform_and_write_output_files(self, output_file: str) -> None:

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -17,7 +17,8 @@ from attrs import asdict
 # should not be a security issue.
 import transmogrifier.models as timdex
 from transmogrifier.config import SOURCES
-from transmogrifier.helpers import DeletedRecordEvent, generate_citation, validate_date
+from transmogrifier.exceptions import DeletedRecordEvent, SkippedRecordEvent
+from transmogrifier.helpers import generate_citation, validate_date
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -67,6 +68,9 @@ class Transformer(ABC):
                 record = self.transform(source_record)
             except DeletedRecordEvent as error:
                 self.deleted_records.append(error.timdex_record_id)
+                continue
+            except SkippedRecordEvent:
+                self.skipped_record_count += 1
                 continue
             if record:
                 self.transformed_record_count += 1

--- a/transmogrifier/sources/xml/datacite.py
+++ b/transmogrifier/sources/xml/datacite.py
@@ -56,7 +56,7 @@ class Datacite(XMLTransformer):
                     fields["content_type"] = [content_type]
                 else:
                     message = f'Record skipped based on content type: "{content_type}"'
-                    raise SkippedRecordEvent(source_record_id, message)
+                    raise SkippedRecordEvent(message, source_record_id)
         else:
             logger.warning(
                 "Datacite record %s missing required Datacite field resourceType",

--- a/transmogrifier/sources/xml/datacite.py
+++ b/transmogrifier/sources/xml/datacite.py
@@ -3,6 +3,7 @@ import logging
 from bs4 import Tag  # type: ignore[import-untyped]
 
 import transmogrifier.models as timdex
+from transmogrifier.exceptions import SkippedRecordEvent
 from transmogrifier.helpers import validate_date, validate_date_range
 from transmogrifier.sources.xmltransformer import XMLTransformer
 
@@ -54,7 +55,7 @@ class Datacite(XMLTransformer):
                 if self.valid_content_types([content_type]):
                     fields["content_type"] = [content_type]
                 else:
-                    return None
+                    raise SkippedRecordEvent(source_record_id)
         else:
             logger.warning(
                 "Datacite record %s missing required Datacite field resourceType",

--- a/transmogrifier/sources/xml/datacite.py
+++ b/transmogrifier/sources/xml/datacite.py
@@ -55,7 +55,8 @@ class Datacite(XMLTransformer):
                 if self.valid_content_types([content_type]):
                     fields["content_type"] = [content_type]
                 else:
-                    raise SkippedRecordEvent(source_record_id)
+                    message = f'Record skipped based on content type: "{content_type}"'
+                    raise SkippedRecordEvent(source_record_id, message)
         else:
             logger.warning(
                 "Datacite record %s missing required Datacite field resourceType",


### PR DESCRIPTION
### Purpose and background context
Adding more explicit flow control through exception handling in the `Transformer` class. Previously, records were skipped when `get_optional_fields` returned `None`. Adding a `SkippedRecordEvent` exception that can handle records that should be skipped for an invalid `content_type` or records with significant structural issues that raise the risk of unknown exceptions later in the process. This is a minor update to the orchestration that should aid us with the field method refactor.

As we proceed with the refactor in other transforms, use the `SkippedRecordEvent` exception whenever `get_optional_fields` returns `None`. Logging can be added as necessary depending on what triggered the skip.

### How can a reviewer manually see the effects of these changes?
The `Datacite` class was updated to raise  the`SkippedRecordEvent` exception illustrating that tests such as `test_zenodo_skips_records_with_invalid_content_types` still pass.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- NA

### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

