### PR TITLE
Add 1st set of Datacite field methods

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,11 +43,22 @@ def runner():
     return CliRunner()
 
 
+# aardvark ##########################
+
+
+@pytest.fixture
+def aardvark_records():
+    return JSONTransformer.parse_source_file("tests/fixtures/aardvark_records.jsonl")
+
+
 @pytest.fixture
 def aardvark_record_all_fields():
     return JSONTransformer.parse_source_file(
         "tests/fixtures/aardvark/aardvark_record_all_fields.jsonl"
     )
+
+
+# datacite ##########################
 
 
 @pytest.fixture
@@ -66,8 +77,22 @@ def datacite_record_all_fields():
 
 
 @pytest.fixture
-def aardvark_records():
-    return JSONTransformer.parse_source_file("tests/fixtures/aardvark_records.jsonl")
+def datacite_record_optional_fields_blank():
+    source_records = XMLTransformer.parse_source_file(
+        "tests/fixtures/datacite/datacite_record_optional_fields_blank.xml"
+    )
+    return next(source_records)
+
+
+@pytest.fixture
+def datacite_record_optional_fields_missing():
+    source_records = XMLTransformer.parse_source_file(
+        "tests/fixtures/datacite/datacite_record_optional_fields_missing.xml"
+    )
+    return next(source_records)
+
+
+# marc ##########################
 
 
 @pytest.fixture
@@ -80,9 +105,15 @@ def marc_content_type_crosswalk():
     return load_external_config("config/marc_content_type_crosswalk.json", "json")
 
 
+# oaidc ##########################
+
+
 @pytest.fixture
 def oai_pmh_records():
     return XMLTransformer.parse_source_file("tests/fixtures/oai_pmh_records.xml")
+
+
+# timdex ##########################
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,22 +76,6 @@ def datacite_record_all_fields():
     return Datacite("cool-repo", source_records)
 
 
-@pytest.fixture
-def datacite_record_optional_fields_blank():
-    source_records = XMLTransformer.parse_source_file(
-        "tests/fixtures/datacite/datacite_record_optional_fields_blank.xml"
-    )
-    return next(source_records)
-
-
-@pytest.fixture
-def datacite_record_optional_fields_missing():
-    source_records = XMLTransformer.parse_source_file(
-        "tests/fixtures/datacite/datacite_record_optional_fields_missing.xml"
-    )
-    return next(source_records)
-
-
 # marc ##########################
 
 

--- a/tests/fixtures/datacite/datacite_record_all_fields.xml
+++ b/tests/fixtures/datacite/datacite_record_all_fields.xml
@@ -1,125 +1,128 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<record xmlns="http://www.openarchives.org/OAI/2.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <header>
-        <identifier>doi:10.7910/DVN/19PPE7</identifier>
-        <datestamp>2022-03-26T06:04:55Z</datestamp>
-        <setSpec>Jameel_Poverty_Action_Lab</setSpec>
-        <setSpec>IQSS</setSpec>
-    </header>
-    <metadata>
-        <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
-            <identifier identifierType="DOI">10.7910/DVN/19PPE7</identifier>
-            <creators>
-                <creator>
-                    <creatorName nameType="Personal">Banerji, Rukmini</creatorName>
-                    <givenName>Rukmini</givenName>
-                    <familyName>Banerji</familyName>
-                    <affiliation>Pratham and ASER Centre</affiliation>
-                    <nameIdentifier nameIdentifierScheme="ORCID">0000-0000-0000-0000</nameIdentifier>
-                </creator>
-                <creator>
-                    <creatorName nameType="Personal">Berry, James</creatorName>
-                    <givenName>James</givenName>
-                    <familyName>Berry</familyName>
-                    <affiliation>University of Delaware</affiliation>
-                    <nameIdentifier nameIdentifierScheme="TREX">0000-0000-0000-0001</nameIdentifier>
-                </creator>
-                <creator>
-                    <creatorName nameType="Personal">Shotland, Marc</creatorName>
-                    <givenName>Marc</givenName>
-                    <familyName>Shotland</familyName>
-                    <affiliation>Abdul Latif Jameel Poverty Action Lab</affiliation>
-                    <nameIdentifier>0000-0000-0000-0002</nameIdentifier>
-                </creator>
-            </creators>
-            <titles>
-                <title>The Impact of Maternal Literacy and Participation Programs</title>
-                <title titleType="AlternativeTitle">An Alternative Title</title>
-                <title titleType="Subtitle">Baseline Data</title>
-            </titles>
-            <publisher>Harvard Dataverse</publisher>
-            <publicationYear>2017</publicationYear>
-            <subjects>
-                <subject>Social Sciences</subject>
-                <subject>Educational materials</subject>
-                <subject subjectScheme="LCSH">Adult education, education inputs, field experiments</subject>
-                <subject subjectScheme="LCSH">Education</subject>
-            </subjects>
-            <alternateIdentifiers>
-                <alternateIdentifier alternateIdentifierType="url">https://zenodo.org/record/5524465</alternateIdentifier>
-            </alternateIdentifiers>
-            <contributors>
-                <contributor contributorType="ContactPerson">
-                    <contributorName nameType="Personal">Banerji, Rukmini</contributorName>
-                    <givenName>Rukmini</givenName>
-                    <familyName>Banerji</familyName>
-                    <nameIdentifier nameIdentifierScheme="ORCID">0000-0000-0000-0000</nameIdentifier>
-                    <affiliation>Pratham and ASER Centre</affiliation>
-                </contributor>
-            </contributors>
-            <dates>
-                <date dateType="Submitted">2017-02-27</date>
-                <date dateType="Updated" dateInformation="This was updated on this date">2019-06-24</date>
-                <date dateType="Collected">2007-01-01/2007-02-28</date>
-            </dates>
-            <resourceType resourceTypeGeneral="Dataset">Survey Data</resourceType>
-            <relatedIdentifiers>
-                <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1257/app.20150390</relatedIdentifier>
-                <relatedIdentifier relationType="IsVersionOf">10.5281/zenodo.5524464</relatedIdentifier>
-                <relatedIdentifier relatedIdentifierType="ISBN" relationType="IsIdenticalTo">1234567.5524464</relatedIdentifier>
-                <relatedIdentifier relatedIdentifierType="ISBN" relationType="Other">1234567.5524464</relatedIdentifier>
-                <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">https://zenodo.org/communities/astronomy-general</relatedIdentifier>
-            </relatedIdentifiers>
-            <language>en_US</language>
-            <sizes>
-                <size>124903</size>
-                <size>48958</size>
-                <size>199070</size>
-                <size>186674</size>
-                <size>139605</size>
-                <size>97304</size>
-                <size>9907</size>
-                <size>178534602</size>
-                <size>4032103</size>
-                <size>43589</size>
-                <size>15697</size>
-            </sizes>
-            <formats>
-                <format>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</format>
-                <format>application/pdf</format>
-                <format>application/pdf</format>
-                <format>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</format>
-                <format>application/pdf</format>
-                <format>application/x-stata-syntax</format>
-                <format>application/x-stata</format>
-                <format>application/x-stata</format>
-                <format>application/zip</format>
-                <format>application/pdf</format>
-                <format>application/pdf</format>
-            </formats>
-            <version>1.2</version>
-            <rightsList>
-                <rights rightsURI="info:eu-repo/semantics/openAccess" />
-                <rights rightsURI="http://creativecommons.org/publicdomain/zero/1.0">CC0 1.0</rights>
-            </rightsList>
-            <descriptions>
-                <description descriptionType="Abstract">Using a randomized field experiment in India, we evaluate the effectiveness of adult literacy and parental involvement interventions in improving children's learning. Households were assigned to receive either adult literacy (language and math) classes for mothers, training for mothers on how to enhance their children's learning at home, or a combination of the two programs. All three interventions had significant but modest impacts on childrens math scores. The interventions also increased mothers' test scores in both language and math, as well as a range of other outcomes reflecting greater involvement of mothers in their children's education.</description>
-                <description descriptionType="TechnicalInfo">Stata, 13</description>
-            </descriptions>
-            <geoLocations>
-                <geoLocation>
-                    <geoLocationPlace>A point on the globe</geoLocationPlace>
-                </geoLocation>
-            </geoLocations>
-            <fundingReferences>
-                <fundingReference>
-                    <funderName>3ie, Nike Foundation</funderName>
-                    <funderIdentifier funderIdentifierType="Crossref FunderID">0987</funderIdentifier>
-                    <awardNumber awardURI="http://awards.example/7689">OW1/1012 (3ie)</awardNumber>
-                </fundingReference>
-            </fundingReferences>
-        </resource>
-    </metadata>
-</record>
+<records>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <header>
+            <identifier>doi:10.7910/DVN/19PPE7</identifier>
+            <datestamp>2022-03-26T06:04:55Z</datestamp>
+            <setSpec>Jameel_Poverty_Action_Lab</setSpec>
+            <setSpec>IQSS</setSpec>
+        </header>
+        <metadata>
+            <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns="http://datacite.org/schema/kernel-4"
+                xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+                <identifier identifierType="DOI">10.7910/DVN/19PPE7</identifier>
+                <creators>
+                    <creator>
+                        <creatorName nameType="Personal">Banerji, Rukmini</creatorName>
+                        <givenName>Rukmini</givenName>
+                        <familyName>Banerji</familyName>
+                        <affiliation>Pratham and ASER Centre</affiliation>
+                        <nameIdentifier nameIdentifierScheme="ORCID">0000-0000-0000-0000</nameIdentifier>
+                    </creator>
+                    <creator>
+                        <creatorName nameType="Personal">Berry, James</creatorName>
+                        <givenName>James</givenName>
+                        <familyName>Berry</familyName>
+                        <affiliation>University of Delaware</affiliation>
+                        <nameIdentifier nameIdentifierScheme="TREX">0000-0000-0000-0001</nameIdentifier>
+                    </creator>
+                    <creator>
+                        <creatorName nameType="Personal">Shotland, Marc</creatorName>
+                        <givenName>Marc</givenName>
+                        <familyName>Shotland</familyName>
+                        <affiliation>Abdul Latif Jameel Poverty Action Lab</affiliation>
+                        <nameIdentifier>0000-0000-0000-0002</nameIdentifier>
+                    </creator>
+                </creators>
+                <titles>
+                    <title>The Impact of Maternal Literacy and Participation Programs</title>
+                    <title titleType="AlternativeTitle">An Alternative Title</title>
+                    <title titleType="Subtitle">Baseline Data</title>
+                </titles>
+                <publisher>Harvard Dataverse</publisher>
+                <publicationYear>2017</publicationYear>
+                <subjects>
+                    <subject>Social Sciences</subject>
+                    <subject>Educational materials</subject>
+                    <subject subjectScheme="LCSH">Adult education, education inputs, field experiments</subject>
+                    <subject subjectScheme="LCSH">Education</subject>
+                </subjects>
+                <alternateIdentifiers>
+                    <alternateIdentifier alternateIdentifierType="url">https://zenodo.org/record/5524465</alternateIdentifier>
+                </alternateIdentifiers>
+                <contributors>
+                    <contributor contributorType="ContactPerson">
+                        <contributorName nameType="Personal">Banerji, Rukmini</contributorName>
+                        <givenName>Rukmini</givenName>
+                        <familyName>Banerji</familyName>
+                        <nameIdentifier nameIdentifierScheme="ORCID">0000-0000-0000-0000</nameIdentifier>
+                        <affiliation>Pratham and ASER Centre</affiliation>
+                    </contributor>
+                </contributors>
+                <dates>
+                    <date dateType="Submitted">2017-02-27</date>
+                    <date dateType="Updated" dateInformation="This was updated on this date">2019-06-24</date>
+                    <date dateType="Collected">2007-01-01/2007-02-28</date>
+                </dates>
+                <resourceType resourceTypeGeneral="Dataset">Survey Data</resourceType>
+                <relatedIdentifiers>
+                    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsCitedBy">10.1257/app.20150390</relatedIdentifier>
+                    <relatedIdentifier relationType="IsVersionOf">10.5281/zenodo.5524464</relatedIdentifier>
+                    <relatedIdentifier relatedIdentifierType="ISBN" relationType="IsIdenticalTo">1234567.5524464</relatedIdentifier>
+                    <relatedIdentifier relatedIdentifierType="ISBN" relationType="Other">1234567.5524464</relatedIdentifier>
+                    <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">https://zenodo.org/communities/astronomy-general</relatedIdentifier>
+                </relatedIdentifiers>
+                <language>en_US</language>
+                <sizes>
+                    <size>124903</size>
+                    <size>48958</size>
+                    <size>199070</size>
+                    <size>186674</size>
+                    <size>139605</size>
+                    <size>97304</size>
+                    <size>9907</size>
+                    <size>178534602</size>
+                    <size>4032103</size>
+                    <size>43589</size>
+                    <size>15697</size>
+                </sizes>
+                <formats>
+                    <format>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</format>
+                    <format>application/pdf</format>
+                    <format>application/pdf</format>
+                    <format>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</format>
+                    <format>application/pdf</format>
+                    <format>application/x-stata-syntax</format>
+                    <format>application/x-stata</format>
+                    <format>application/x-stata</format>
+                    <format>application/zip</format>
+                    <format>application/pdf</format>
+                    <format>application/pdf</format>
+                </formats>
+                <version>1.2</version>
+                <rightsList>
+                    <rights rightsURI="info:eu-repo/semantics/openAccess" />
+                    <rights rightsURI="http://creativecommons.org/publicdomain/zero/1.0">CC0 1.0</rights>
+                </rightsList>
+                <descriptions>
+                    <description descriptionType="Abstract">Using a randomized field experiment in India, we evaluate the effectiveness of adult literacy and parental involvement interventions in improving children's learning. Households were assigned to receive either adult literacy (language and math) classes for mothers, training for mothers on how to enhance their children's learning at home, or a combination of the two programs. All three interventions had significant but modest impacts on childrens math scores. The interventions also increased mothers' test scores in both language and math, as well as a range of other outcomes reflecting greater involvement of mothers in their children's education.</description>
+                    <description descriptionType="TechnicalInfo">Stata, 13</description>
+                </descriptions>
+                <geoLocations>
+                    <geoLocation>
+                        <geoLocationPlace>A point on the globe</geoLocationPlace>
+                    </geoLocation>
+                </geoLocations>
+                <fundingReferences>
+                    <fundingReference>
+                        <funderName>3ie, Nike Foundation</funderName>
+                        <funderIdentifier funderIdentifierType="Crossref FunderID">0987</funderIdentifier>
+                        <awardNumber awardURI="http://awards.example/7689">OW1/1012 (3ie)</awardNumber>
+                    </fundingReference>
+                </fundingReferences>
+            </resource>
+        </metadata>
+    </record>
+</records>

--- a/tests/sources/xml/test_datacite.py
+++ b/tests/sources/xml/test_datacite.py
@@ -19,11 +19,14 @@ from transmogrifier.models import (
 from transmogrifier.sources.xml.datacite import Datacite
 
 
-def create_datacite_source_record_stub(xml_insert: str) -> BeautifulSoup:
+def create_datacite_source_record_stub(xml_insert: str = "") -> BeautifulSoup:
     xml_string = f"""
         <records>
          <record xmlns="http://www.openarchives.org/OAI/2.0/"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <header>
+            <identifier>abc123</identifier>
+          <header>
           <metadata>
            <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns="http://datacite.org/schema/kernel-4"
@@ -404,7 +407,7 @@ def test_get_alternate_titles_transforms_correctly_if_fields_blank():
 
 
 def test_get_alternate_titles_transforms_correctly_if_fields_missing():
-    source_record = create_datacite_source_record_stub("")
+    source_record = create_datacite_source_record_stub()
     assert Datacite.get_alternate_titles(source_record) is None
 
 
@@ -414,7 +417,7 @@ def test_get_content_type_success():
         <resourceType resourceTypeGeneral="Dataset">Survey Data</resourceType>
         """
     )
-    assert Datacite.get_content_type(source_record, "abc123") == ["Dataset"]
+    assert Datacite.get_content_type(source_record) == ["Dataset"]
 
 
 def test_get_content_type_transforms_correctly_if_fields_blank():
@@ -423,12 +426,12 @@ def test_get_content_type_transforms_correctly_if_fields_blank():
         <resourceType resourceTypeGeneral=""></resourceType>
         """
     )
-    assert Datacite.get_content_type(source_record, "abc123") is None
+    assert Datacite.get_content_type(source_record) is None
 
 
 def test_get_content_type_transforms_correctly_if_fields_missing():
-    source_record = create_datacite_source_record_stub("")
-    assert Datacite.get_content_type(source_record, "abc123") is None
+    source_record = create_datacite_source_record_stub()
+    assert Datacite.get_content_type(source_record) is None
 
 
 def test_get_contributors_success():
@@ -510,7 +513,7 @@ def test_get_contributors_transforms_correctly_if_fields_blank():
 
 
 def test_get_contributors_transforms_correctly_if_fields_missing():
-    source_record = create_datacite_source_record_stub("")
+    source_record = create_datacite_source_record_stub()
     assert Datacite.get_contributors(source_record) is None
 
 

--- a/tests/sources/xml/test_datacite.py
+++ b/tests/sources/xml/test_datacite.py
@@ -396,16 +396,16 @@ def test_get_alternate_titles_success():
     ]
 
 
-def test_get_alternate_titles_transforms_correctly_if_fields_blank(
-    datacite_record_optional_fields_blank,
-):
-    assert Datacite.get_alternate_titles(datacite_record_optional_fields_blank) == []
+def test_get_alternate_titles_transforms_correctly_if_fields_blank():
+    source_record = create_datacite_source_record_stub(
+        '<titles><title titleType="AlternativeTitle"></title></titles>'
+    )
+    assert Datacite.get_alternate_titles(source_record) is None
 
 
-def test_get_alternate_titles_transforms_correctly_if_fields_missing(
-    datacite_record_optional_fields_missing,
-):
-    assert Datacite.get_alternate_titles(datacite_record_optional_fields_missing) == []
+def test_get_alternate_titles_transforms_correctly_if_fields_missing():
+    source_record = create_datacite_source_record_stub("")
+    assert Datacite.get_alternate_titles(source_record) is None
 
 
 def test_get_content_type_success():
@@ -417,20 +417,18 @@ def test_get_content_type_success():
     assert Datacite.get_content_type(source_record, "abc123") == ["Dataset"]
 
 
-def test_get_content_type_transforms_correctly_if_fields_blank(
-    datacite_record_optional_fields_blank,
-):
-    assert (
-        Datacite.get_content_type(datacite_record_optional_fields_blank, "abc123") == []
+def test_get_content_type_transforms_correctly_if_fields_blank():
+    source_record = create_datacite_source_record_stub(
+        """
+        <resourceType resourceTypeGeneral=""></resourceType>
+        """
     )
+    assert Datacite.get_content_type(source_record, "abc123") is None
 
 
-def test_get_content_type_transforms_correctly_if_fields_missing(
-    datacite_record_optional_fields_missing,
-):
-    assert (
-        Datacite.get_content_type(datacite_record_optional_fields_missing, "abc123") == []
-    )
+def test_get_content_type_transforms_correctly_if_fields_missing():
+    source_record = create_datacite_source_record_stub("")
+    assert Datacite.get_content_type(source_record, "abc123") is None
 
 
 def test_get_contributors_success():
@@ -498,16 +496,22 @@ def test_get_contributors_success():
     ]
 
 
-def test_get_contributors_transforms_correctly_if_fields_blank(
-    datacite_record_optional_fields_blank,
-):
-    assert Datacite.get_contributors(datacite_record_optional_fields_blank) == []
+def test_get_contributors_transforms_correctly_if_fields_blank():
+    source_record = create_datacite_source_record_stub(
+        """
+        <creators>
+         <creator />
+        <contributors>
+         <contributor />
+        </contributors>
+        """
+    )
+    assert Datacite.get_contributors(source_record) is None
 
 
-def test_get_contributors_transforms_correctly_if_fields_missing(
-    datacite_record_optional_fields_missing,
-):
-    assert Datacite.get_contributors(datacite_record_optional_fields_missing) == []
+def test_get_contributors_transforms_correctly_if_fields_missing():
+    source_record = create_datacite_source_record_stub("")
+    assert Datacite.get_contributors(source_record) is None
 
 
 def test_generate_name_identifier_url_orcid_scheme(datacite_record_all_fields):

--- a/tests/sources/xml/test_datacite.py
+++ b/tests/sources/xml/test_datacite.py
@@ -1,3 +1,5 @@
+from bs4 import BeautifulSoup
+
 from transmogrifier.models import (
     AlternateTitle,
     Contributor,
@@ -15,6 +17,25 @@ from transmogrifier.models import (
     TimdexRecord,
 )
 from transmogrifier.sources.xml.datacite import Datacite
+
+
+def create_datacite_source_record_stub(xml_insert: str) -> BeautifulSoup:
+    xml_string = f"""
+        <records>
+         <record xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <metadata>
+           <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://datacite.org/schema/kernel-4"
+           xsi:schemaLocation="http://datacite.org/schema/kernel-4
+           http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
+           {xml_insert}
+           </resource>
+          </metadata>
+         </record>
+        </records>
+        """
+    return BeautifulSoup(xml_string, "xml")
 
 
 def test_datacite_transform_with_all_fields_transforms_correctly(
@@ -357,6 +378,136 @@ def test_datacite_with_attribute_and_subfield_variations_transforms_correctly():
         ],
         subjects=[Subject(value=["Subject One"], kind="Subject scheme not provided")],
     )
+
+
+def test_get_alternate_titles_success():
+    source_record = create_datacite_source_record_stub(
+        """
+        <titles>
+         <title>The Impact of Maternal Literacy and Participation Programs</title>
+         <title titleType="AlternativeTitle">An Alternative Title</title>
+         <title titleType="Subtitle">Baseline Data</title>
+        </titles>
+        """
+    )
+    assert Datacite.get_alternate_titles(source_record) == [
+        AlternateTitle(value="An Alternative Title", kind="AlternativeTitle"),
+        AlternateTitle(value="Baseline Data", kind="Subtitle"),
+    ]
+
+
+def test_get_alternate_titles_transforms_correctly_if_fields_blank(
+    datacite_record_optional_fields_blank,
+):
+    assert Datacite.get_alternate_titles(datacite_record_optional_fields_blank) == []
+
+
+def test_get_alternate_titles_transforms_correctly_if_fields_missing(
+    datacite_record_optional_fields_missing,
+):
+    assert Datacite.get_alternate_titles(datacite_record_optional_fields_missing) == []
+
+
+def test_get_content_type_success():
+    source_record = create_datacite_source_record_stub(
+        """
+        <resourceType resourceTypeGeneral="Dataset">Survey Data</resourceType>
+        """
+    )
+    assert Datacite.get_content_type(source_record, "abc123") == ["Dataset"]
+
+
+def test_get_content_type_transforms_correctly_if_fields_blank(
+    datacite_record_optional_fields_blank,
+):
+    assert (
+        Datacite.get_content_type(datacite_record_optional_fields_blank, "abc123") == []
+    )
+
+
+def test_get_content_type_transforms_correctly_if_fields_missing(
+    datacite_record_optional_fields_missing,
+):
+    assert (
+        Datacite.get_content_type(datacite_record_optional_fields_missing, "abc123") == []
+    )
+
+
+def test_get_contributors_success():
+    source_record = create_datacite_source_record_stub(
+        """
+        <creators>
+         <creator>
+          <creatorName nameType="Personal">Banerji, Rukmini</creatorName>
+          <givenName>Rukmini</givenName>
+          <familyName>Banerji</familyName>
+          <affiliation>Pratham and ASER Centre</affiliation>
+        <nameIdentifier nameIdentifierScheme="ORCID">0000-0000-0000-0000</nameIdentifier>
+         </creator>
+         <creator>
+          <creatorName nameType="Personal">Berry, James</creatorName>
+          <givenName>James</givenName>
+          <familyName>Berry</familyName>
+          <affiliation>University of Delaware</affiliation>
+          <nameIdentifier nameIdentifierScheme="TREX">0000-0000-0000-0001</nameIdentifier>
+          </creator>
+         <creator>
+          <creatorName nameType="Personal">Shotland, Marc</creatorName>
+          <givenName>Marc</givenName>
+          <familyName>Shotland</familyName>
+          <affiliation>Abdul Latif Jameel Poverty Action Lab</affiliation>
+          <nameIdentifier>0000-0000-0000-0002</nameIdentifier>
+         </creator>
+         </creators>
+        <contributors>
+         <contributor contributorType="ContactPerson">
+          <contributorName nameType="Personal">Banerji, Rukmini</contributorName>
+          <givenName>Rukmini</givenName>
+          <familyName>Banerji</familyName>
+        <nameIdentifier nameIdentifierScheme="ORCID">0000-0000-0000-0000</nameIdentifier>
+          <affiliation>Pratham and ASER Centre</affiliation>
+         </contributor>
+        </contributors>
+        """
+    )
+    assert Datacite.get_contributors(source_record) == [
+        Contributor(
+            value="Banerji, Rukmini",
+            affiliation=["Pratham and ASER Centre"],
+            identifier=["https://orcid.org/0000-0000-0000-0000"],
+            kind="Creator",
+        ),
+        Contributor(
+            value="Berry, James",
+            affiliation=["University of Delaware"],
+            identifier=["0000-0000-0000-0001"],
+            kind="Creator",
+        ),
+        Contributor(
+            value="Shotland, Marc",
+            affiliation=["Abdul Latif Jameel Poverty Action Lab"],
+            identifier=["0000-0000-0000-0002"],
+            kind="Creator",
+        ),
+        Contributor(
+            value="Banerji, Rukmini",
+            affiliation=["Pratham and ASER Centre"],
+            identifier=["https://orcid.org/0000-0000-0000-0000"],
+            kind="ContactPerson",
+        ),
+    ]
+
+
+def test_get_contributors_transforms_correctly_if_fields_blank(
+    datacite_record_optional_fields_blank,
+):
+    assert Datacite.get_contributors(datacite_record_optional_fields_blank) == []
+
+
+def test_get_contributors_transforms_correctly_if_fields_missing(
+    datacite_record_optional_fields_missing,
+):
+    assert Datacite.get_contributors(datacite_record_optional_fields_missing) == []
 
 
 def test_generate_name_identifier_url_orcid_scheme(datacite_record_all_fields):

--- a/transmogrifier/sources/xml/datacite.py
+++ b/transmogrifier/sources/xml/datacite.py
@@ -249,17 +249,14 @@ class Datacite(XMLTransformer):
     def get_alternate_titles(
         cls, source_record: Tag
     ) -> list[timdex.AlternateTitle] | None:
-        alternate_titles = []
-        alternate_titles.extend(
-            [
-                timdex.AlternateTitle(
-                    value=str(title.string.strip()),
-                    kind=title["titleType"],
-                )
-                for title in source_record.find_all("title", string=True)
-                if title.get("titleType")
-            ]
-        )
+        alternate_titles = [
+            timdex.AlternateTitle(
+                value=str(title.string.strip()),
+                kind=title["titleType"],
+            )
+            for title in source_record.find_all("title", string=True)
+            if title.get("titleType")
+        ]
         alternate_titles.extend(list(cls._get_additional_titles(source_record)))
         return alternate_titles or None
 

--- a/transmogrifier/sources/xml/datacite.py
+++ b/transmogrifier/sources/xml/datacite.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterator
 
 from bs4 import Tag  # type: ignore[import-untyped]
 
@@ -13,100 +14,34 @@ logger = logging.getLogger(__name__)
 class Datacite(XMLTransformer):
     """Datacite transformer."""
 
-    def get_optional_fields(self, xml: Tag) -> dict | None:
+    def get_optional_fields(self, source_record: Tag) -> dict | None:
         """
         Retrieve optional TIMDEX fields from a Datacite XML record.
 
         Overrides metaclass get_optional_fields() method.
 
         Args:
-            xml: A BeautifulSoup Tag representing a single Datacite record in
+            source_record: A BeautifulSoup Tag representing a single Datacite record in
                 oai_datacite XML.
         """
         fields: dict = {}
-        source_record_id = self.get_source_record_id(xml)
+        source_record_id = self.get_source_record_id(source_record)
 
         # alternate_titles
-        for alternate_title in [
-            t for t in xml.find_all("title", string=True) if t.get("titleType")
-        ]:
-            fields.setdefault("alternate_titles", []).append(
-                timdex.AlternateTitle(
-                    value=alternate_title.string,
-                    kind=alternate_title["titleType"],
-                )
-            )
-        # If the record has more than one main title, add extras to alternate_titles
-        for index, title in enumerate(self.get_main_titles(xml)):
-            if index > 0:
-                fields.setdefault("alternate_titles", []).append(
-                    timdex.AlternateTitle(value=title)
-                )
+        fields["alternate_titles"] = self.get_alternate_titles(source_record) or None
 
         # content_type
-        if resource_type := xml.metadata.find("resourceType"):
-            if resource_type.string:
-                fields["notes"] = [
-                    timdex.Note(
-                        value=[resource_type.string], kind="Datacite resource type"
-                    )
-                ]
-            if content_type := resource_type.get("resourceTypeGeneral"):
-                if self.valid_content_types([content_type]):
-                    fields["content_type"] = [content_type]
-                else:
-                    message = f'Record skipped based on content type: "{content_type}"'
-                    raise SkippedRecordEvent(message, source_record_id)
-        else:
-            logger.warning(
-                "Datacite record %s missing required Datacite field resourceType",
-                source_record_id,
-            )
+        fields["content_type"] = (
+            self.get_content_type(source_record, source_record_id) or None
+        )
 
         # contributors
-        for creator in xml.metadata.find_all("creator"):
-            if creator_name := creator.find("creatorName", string=True):
-                fields.setdefault("contributors", []).append(
-                    timdex.Contributor(
-                        value=creator_name.string,
-                        affiliation=[
-                            a.string for a in creator.find_all("affiliation", string=True)
-                        ]
-                        or None,
-                        identifier=[
-                            self.generate_name_identifier_url(name_identifier)
-                            for name_identifier in creator.find_all(
-                                "nameIdentifier", string=True
-                            )
-                        ]
-                        or None,
-                        kind="Creator",
-                    )
-                )
-
-        for contributor in xml.metadata.find_all("contributor"):
-            if contributor_name := contributor.find("contributorName", string=True):
-                fields.setdefault("contributors", []).append(
-                    timdex.Contributor(
-                        value=contributor_name.string,
-                        affiliation=[
-                            a.string
-                            for a in contributor.find_all("affiliation", string=True)
-                        ]
-                        or None,
-                        identifier=[
-                            self.generate_name_identifier_url(name_identifier)
-                            for name_identifier in contributor.find_all(
-                                "nameIdentifier", string=True
-                            )
-                        ]
-                        or None,
-                        kind=contributor.get("contributorType") or "Not specified",
-                    )
-                )
+        fields["contributors"] = self.get_contributors(source_record) or None
 
         # dates
-        if publication_year := xml.metadata.find("publicationYear", string=True):
+        if publication_year := source_record.metadata.find(
+            "publicationYear", string=True
+        ):
             publication_year = str(publication_year.string.strip())
             if validate_date(
                 publication_year,
@@ -121,7 +56,7 @@ class Datacite(XMLTransformer):
                 source_record_id,
             )
 
-        for date in xml.metadata.find_all("date"):
+        for date in source_record.metadata.find_all("date"):
             d = timdex.Date()
             if date_value := date.string:
                 date_value = str(date_value)
@@ -153,19 +88,19 @@ class Datacite(XMLTransformer):
                 fields.setdefault("dates", []).append(d)
 
         # edition
-        if edition := xml.metadata.find("version", string=True):
+        if edition := source_record.metadata.find("version", string=True):
             fields["edition"] = edition.string
 
         # file_formats
         fields["file_formats"] = [
-            f.string for f in xml.metadata.find_all("format", string=True)
+            f.string for f in source_record.metadata.find_all("format", string=True)
         ] or None
 
         # format
         fields["format"] = "electronic resource"
 
         # funding_information
-        for funding_reference in xml.metadata.find_all("fundingReference"):
+        for funding_reference in source_record.metadata.find_all("fundingReference"):
             f = timdex.Funder()
             if funder_name := funding_reference.find("funderName", string=True):
                 f.funder_name = funder_name.string
@@ -183,14 +118,14 @@ class Datacite(XMLTransformer):
                 fields.setdefault("funding_information", []).append(f)
 
         # identifiers
-        if identifier_xml := xml.metadata.find("identifier", string=True):
+        if identifier_xml := source_record.metadata.find("identifier", string=True):
             fields.setdefault("identifiers", []).append(
                 timdex.Identifier(
                     value=identifier_xml.string,
                     kind=identifier_xml.get("identifierType") or "Not specified",
                 )
             )
-        for alternate_identifier in xml.metadata.find_all(
+        for alternate_identifier in source_record.metadata.find_all(
             "alternateIdentifier", string=True
         ):
             fields.setdefault("identifiers", []).append(
@@ -201,7 +136,9 @@ class Datacite(XMLTransformer):
                 )
             )
 
-        related_identifiers = xml.metadata.find_all("relatedIdentifier", string=True)
+        related_identifiers = source_record.metadata.find_all(
+            "relatedIdentifier", string=True
+        )
         for related_identifier in [
             ri for ri in related_identifiers if ri.get("relationType") == "IsIdenticalTo"
         ]:
@@ -213,7 +150,7 @@ class Datacite(XMLTransformer):
             )
 
         # language
-        if language := xml.metadata.find("language", string=True):
+        if language := source_record.metadata.find("language", string=True):
             fields["languages"] = [language.string]
 
         # links
@@ -226,13 +163,20 @@ class Datacite(XMLTransformer):
         ]
 
         # locations
-        for location in xml.metadata.find_all("geoLocationPlace", string=True):
+        for location in source_record.metadata.find_all("geoLocationPlace", string=True):
             fields.setdefault("locations", []).append(
                 timdex.Location(value=location.string)
             )
 
         # notes
-        descriptions = xml.metadata.find_all("description", string=True)
+        if resource_type := source_record.metadata.find("resourceType", string=True):
+            fields.setdefault("notes", []).append(
+                timdex.Note(
+                    value=[str(resource_type.string)],
+                    kind="Datacite resource type",
+                )
+            )
+        descriptions = source_record.metadata.find_all("description", string=True)
         for description in descriptions:
             if "descriptionType" not in description.attrs:
                 logger.warning(
@@ -249,7 +193,7 @@ class Datacite(XMLTransformer):
                 )
 
         # publishers
-        if publisher := xml.metadata.find("publisher", string=True):
+        if publisher := source_record.metadata.find("publisher", string=True):
             fields["publishers"] = [timdex.Publisher(name=publisher.string)]
         else:
             logger.warning(
@@ -271,7 +215,9 @@ class Datacite(XMLTransformer):
 
         # rights
         for right in [
-            r for r in xml.metadata.find_all("rights") if r.string or r.get("rightsURI")
+            r
+            for r in source_record.metadata.find_all("rights")
+            if r.string or r.get("rightsURI")
         ]:
             fields.setdefault("rights", []).append(
                 timdex.Rights(
@@ -281,7 +227,7 @@ class Datacite(XMLTransformer):
 
         # subjects
         subjects_dict: dict[str, list[str]] = {}
-        for subject in xml.metadata.find_all("subject", string=True):
+        for subject in source_record.metadata.find_all("subject", string=True):
             if not subject.get("subjectScheme"):
                 subjects_dict.setdefault("Subject scheme not provided", []).append(
                     subject.string
@@ -302,20 +248,113 @@ class Datacite(XMLTransformer):
         return fields
 
     @classmethod
-    def get_main_titles(cls, xml: Tag) -> list[str]:
+    def get_alternate_titles(cls, source_record: Tag) -> list[timdex.AlternateTitle]:
+        alternate_titles = []
+        alternate_titles.extend(
+            [
+                timdex.AlternateTitle(
+                    value=str(title.string.strip()),
+                    kind=title["titleType"],
+                )
+                for title in source_record.find_all("title", string=True)
+                if title.get("titleType")
+            ]
+        )
+        alternate_titles.extend(list(cls._get_additional_titles(source_record)))
+        return alternate_titles
+
+    @classmethod
+    def _get_additional_titles(
+        cls, source_record: Tag
+    ) -> Iterator[timdex.AlternateTitle]:
+        """Get additional titles from get_main_titles method."""
+        for index, title in enumerate(cls.get_main_titles(source_record)):
+            if index > 0:
+                yield timdex.AlternateTitle(value=title)
+
+    @classmethod
+    def get_content_type(cls, source_record: Tag, source_record_id: str) -> list[str]:
+        content_types = []
+        if resource_type := source_record.metadata.find("resourceType"):
+            if content_type := resource_type.get("resourceTypeGeneral"):
+                if cls.valid_content_types([content_type]):
+                    content_types.append(str(content_type))
+                else:
+                    message = f'Record skipped based on content type: "{content_type}"'
+                    raise SkippedRecordEvent(message, source_record_id)
+        else:
+            logger.warning(
+                "Datacite record %s missing required Datacite field resourceType",
+                source_record_id,
+            )
+        return content_types
+
+    @classmethod
+    def get_contributors(cls, source_record: Tag) -> list[timdex.Contributor]:
+        contributors = []
+        contributors.extend(list(cls._get_creators(source_record)))
+        contributors.extend(list(cls._get_contributors(source_record)))
+        return contributors
+
+    @classmethod
+    def _get_creators(cls, source_record: Tag) -> Iterator[timdex.Contributor]:
+        for creator in source_record.metadata.find_all("creator"):
+            if creator_name := creator.find("creatorName", string=True):
+                yield timdex.Contributor(
+                    value=str(creator_name.string),
+                    affiliation=[
+                        str(affiliation.string)
+                        for affiliation in creator.find_all("affiliation", string=True)
+                    ]
+                    or None,
+                    identifier=[
+                        cls.generate_name_identifier_url(name_identifier)
+                        for name_identifier in creator.find_all(
+                            "nameIdentifier", string=True
+                        )
+                    ]
+                    or None,
+                    kind="Creator",
+                )
+
+    @classmethod
+    def _get_contributors(cls, source_record: Tag) -> Iterator[timdex.Contributor]:
+        for contributor in source_record.metadata.find_all("contributor"):
+            if contributor_name := contributor.find("contributorName", string=True):
+                yield timdex.Contributor(
+                    value=contributor_name.string,
+                    affiliation=[
+                        str(affiliation.string)
+                        for affiliation in contributor.find_all(
+                            "affiliation", string=True
+                        )
+                    ]
+                    or None,
+                    identifier=[
+                        cls.generate_name_identifier_url(name_identifier)
+                        for name_identifier in contributor.find_all(
+                            "nameIdentifier", string=True
+                        )
+                    ]
+                    or None,
+                    kind=contributor.get("contributorType") or "Not specified",
+                )
+
+    @classmethod
+    def get_main_titles(cls, source_record: Tag) -> list[str]:
         """
         Retrieve main title(s) from a Datacite XML record.
 
         Overrides metaclass get_main_titles() method.
 
         Args:
-            xml: A BeautifulSoup Tag representing a single Datacite record in
+            source_record: A BeautifulSoup Tag representing a single Datacite record in
                 oai_datacite XML.
         """
         return [
-            t.string
-            for t in xml.metadata.find_all("title", string=True)
-            if not t.get("titleType")
+            str(title.string)
+            for title in source_record.metadata.find_all("title", string=True)
+            if not title.get("titleType")
         ]
 
     @classmethod

--- a/transmogrifier/sources/xml/datacite.py
+++ b/transmogrifier/sources/xml/datacite.py
@@ -31,7 +31,7 @@ class Datacite(XMLTransformer):
         fields["alternate_titles"] = self.get_alternate_titles(source_record)
 
         # content_type
-        fields["content_type"] = self.get_content_type(source_record, source_record_id)
+        fields["content_type"] = self.get_content_type(source_record)
 
         # contributors
         fields["contributors"] = self.get_contributors(source_record)
@@ -273,9 +273,7 @@ class Datacite(XMLTransformer):
                 yield timdex.AlternateTitle(value=title)
 
     @classmethod
-    def get_content_type(
-        cls, source_record: Tag, source_record_id: str
-    ) -> list[str] | None:
+    def get_content_type(cls, source_record: Tag) -> list[str] | None:
         content_types = []
         if resource_type := source_record.metadata.find("resourceType"):
             if content_type := resource_type.get("resourceTypeGeneral"):
@@ -283,11 +281,13 @@ class Datacite(XMLTransformer):
                     content_types.append(str(content_type))
                 else:
                     message = f'Record skipped based on content type: "{content_type}"'
-                    raise SkippedRecordEvent(message, source_record_id)
+                    raise SkippedRecordEvent(
+                        message, cls.get_source_record_id(source_record)
+                    )
         else:
             logger.warning(
                 "Datacite record %s missing required Datacite field resourceType",
-                source_record_id,
+                cls.get_source_record_id(source_record),
             )
         return content_types or None
 

--- a/transmogrifier/sources/xml/datacite.py
+++ b/transmogrifier/sources/xml/datacite.py
@@ -28,15 +28,13 @@ class Datacite(XMLTransformer):
         source_record_id = self.get_source_record_id(source_record)
 
         # alternate_titles
-        fields["alternate_titles"] = self.get_alternate_titles(source_record) or None
+        fields["alternate_titles"] = self.get_alternate_titles(source_record)
 
         # content_type
-        fields["content_type"] = (
-            self.get_content_type(source_record, source_record_id) or None
-        )
+        fields["content_type"] = self.get_content_type(source_record, source_record_id)
 
         # contributors
-        fields["contributors"] = self.get_contributors(source_record) or None
+        fields["contributors"] = self.get_contributors(source_record)
 
         # dates
         if publication_year := source_record.metadata.find(
@@ -248,7 +246,9 @@ class Datacite(XMLTransformer):
         return fields
 
     @classmethod
-    def get_alternate_titles(cls, source_record: Tag) -> list[timdex.AlternateTitle]:
+    def get_alternate_titles(
+        cls, source_record: Tag
+    ) -> list[timdex.AlternateTitle] | None:
         alternate_titles = []
         alternate_titles.extend(
             [
@@ -261,7 +261,7 @@ class Datacite(XMLTransformer):
             ]
         )
         alternate_titles.extend(list(cls._get_additional_titles(source_record)))
-        return alternate_titles
+        return alternate_titles or None
 
     @classmethod
     def _get_additional_titles(
@@ -273,7 +273,9 @@ class Datacite(XMLTransformer):
                 yield timdex.AlternateTitle(value=title)
 
     @classmethod
-    def get_content_type(cls, source_record: Tag, source_record_id: str) -> list[str]:
+    def get_content_type(
+        cls, source_record: Tag, source_record_id: str
+    ) -> list[str] | None:
         content_types = []
         if resource_type := source_record.metadata.find("resourceType"):
             if content_type := resource_type.get("resourceTypeGeneral"):
@@ -287,14 +289,14 @@ class Datacite(XMLTransformer):
                 "Datacite record %s missing required Datacite field resourceType",
                 source_record_id,
             )
-        return content_types
+        return content_types or None
 
     @classmethod
-    def get_contributors(cls, source_record: Tag) -> list[timdex.Contributor]:
+    def get_contributors(cls, source_record: Tag) -> list[timdex.Contributor] | None:
         contributors = []
         contributors.extend(list(cls._get_creators(source_record)))
         contributors.extend(list(cls._get_contributors(source_record)))
-        return contributors
+        return contributors or None
 
     @classmethod
     def _get_creators(cls, source_record: Tag) -> Iterator[timdex.Contributor]:


### PR DESCRIPTION
### Purpose and background context
Refactors the first set of `Datacite` fields as separate field methods. As this is the first of many of these PRs that DataEng will be writing/reviewing, I encourage nit-picking so we can refine the overall approach early.

### How can a reviewer manually see the effects of these changes?
Run the following command to see that the `Datacite` transform still transforms a source file:

```
pipenv run transform -i tests/fixtures/datacite/datacite_records.xml -o output/datacite-transformed-records.json -s jpal
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-284

### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

