### PR TITLE
Timx 287 ead field method refactor

### DIFF
--- a/tests/sources/xml/test_ead.py
+++ b/tests/sources/xml/test_ead.py
@@ -1,7 +1,55 @@
 import logging
 
+import pytest
+from bs4 import BeautifulSoup
+
 import transmogrifier.models as timdex
 from transmogrifier.sources.xml.ead import Ead
+
+
+def create_ead_source_record_stub(
+    header_insert: str = "", metadata_insert: str = ""
+) -> BeautifulSoup:
+    """
+    Create source record for unit tests.
+
+    Args:
+        metadata_insert (str): For EAD-formatted XML, data for field methods
+            are located within the Archival Description (<archdesc>) element.
+            Values set for this parameter must be formatted as follows:
+
+            <archdesc level="collection">
+                <did>
+                    {elements}
+                </did>
+                {elements}
+            </archdesc
+
+            Note: {elements} refer to XML elements nested under the <archdesc> and <did>
+                elements.
+    """
+    xml_string = f"""
+        <records>
+            <record xmlns="http://www.openarchives.org/OAI/2.0/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <header>
+                    {header_insert}
+                </header>
+                <metadata>
+                    <ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+                        <eadheader countryencoding="iso3166-1" dateencoding="iso8601"
+                            findaidstatus="completed" langencoding="iso639-2b" repositoryencoding="iso15511">
+                            <eadid countrycode="US" mainagencycode="US-mcm">VC-0002</eadid>
+                        </eadheader>
+                        {metadata_insert}
+                    </ead>
+                </metadata>
+            </record>
+        </records>
+    """
+    return BeautifulSoup(xml_string, "xml")
 
 
 def test_ead_record_all_fields_transform_correctly():


### PR DESCRIPTION
### Purpose and background context
 
A few updates worth noting: 

1. Three (3) "private" methods have been added to retrieve a few key elements from the EAD-formatted XML. These elements are [`<archdesc>`](https://github.com/MITLibraries/transmogrifier/blob/TIMX-287-ead-field-method-refactor/transmogrifier/sources/xml/ead.py#L173-L183), [`<did>`](https://github.com/MITLibraries/transmogrifier/blob/TIMX-287-ead-field-method-refactor/transmogrifier/sources/xml/ead.py#L185-L191), and [`<controlaccess>`](https://github.com/MITLibraries/transmogrifier/blob/TIMX-287-ead-field-method-refactor/transmogrifier/sources/xml/ead.py#L193-L198). 
   * `<archdesc>` and `<did>` are required by the EAD transform; if either element is missing, most (if not all) fields cannot be derived, resulting in a `SkippedRecordEvent`.
   * `<did>` and `<controlaccess>` are descendants of the `<archdesc>` element

2. (Related to 1) The new "private" methods are called inside the field methods. [Previously, the `collection_description`, `collection_description_did`, and `control_access_elements` were derived at the beginning of `get_optional_fields()`](https://github.com/MITLibraries/transmogrifier/blob/main/transmogrifier/sources/xml/ead.py#L33-L54). However, given that `get_optional_fields()` will be removed as part of the upcoming orchestration refactor, it was necessary for these "private" methods to get called _inside_ the field methods that depend on these elements. As expected, this results in repeated calls to the methods. This should be revisited as part of the orchestration work but is outside the scope of this PR.

### How can a reviewer manually see the effects of these changes?
Explain how to see the proposed changes in the application if possible.

Delete this section if it isn't applicable to the PR.

### Includes new or updated dependencies?
YES | NO

### Changes expectations for external applications?
YES | NO

### What are the relevant tickets?
- Include links to Jira Software and/or Jira Service Management tickets here.

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

