### PR TITLE
Add 1st set of DspaceMets field methods

### DIFF
--- a/tests/fixtures/dspace/dspace_mets_record_all_fields.xml
+++ b/tests/fixtures/dspace/dspace_mets_record_all_fields.xml
@@ -1,165 +1,167 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<record xmlns="http://www.openarchives.org/OAI/2.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <header>
-        <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
-        <datestamp>2022-06-01T03:46:27Z</datestamp>
-        <setSpec>com_1721.1_7582</setSpec>
-        <setSpec>hdl_1721.1_7582</setSpec>
-        <setSpec>com_1721.1_7581</setSpec>
-        <setSpec>hdl_1721.1_7581</setSpec>
-        <setSpec>col_1721.1_131023</setSpec>
-        <setSpec>hdl_1721.1_131023</setSpec>
-    </header>
-    <metadata>
-        <mets xmlns="http://www.loc.gov/METS/"
-            xmlns:doc="http://www.lyncode.com/xoai"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
-            <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
-                <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
-                    <name>mit-6</name>
-                </agent>
-            </metsHdr>
-            <dmdSec ID="DMD_1721.1_142832">
-                <mdWrap MDTYPE="MODS">
-                    <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                        <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm type="text">advisor</mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart>Checkelsky, Joseph</mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm type="text">author</mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart>Tatsumi, Yuki</mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm type="text">department</mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart>Massachusetts Institute of Technology. Department of Physics</mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:namePart>Smith, Susie Q.</mods:namePart>
-                            </mods:name>
-                            <mods:extension>
-                                <mods:dateAccessioned encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAccessioned>
-                            </mods:extension>
-                            <mods:extension>
-                                <mods:dateAvailable encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAvailable>
-                            </mods:extension>
-                            <mods:originInfo>
-                                <mods:dateIssued encoding="iso8601">2021-09</mods:dateIssued>
-                            </mods:originInfo>
-                            <mods:identifier type="citation">Tatsumi, Yuki. "Magneto-thermal Transport and Machine Learning-assisted Investigation of Magnetic Materials." Massachusetts Institute of Technology © 2022.</mods:identifier>
-                            <mods:identifier type="uri">https://hdl.handle.net/1721.1/142832</mods:identifier>
-                            <mods:abstract>Heat is carried by different types quasiparticles in crystals, including phonons, charge carriers, and magnetic excitations. In most materials, thermal transport can be understood as the flow of phonons and charge carriers; magnetic heat flow is less well-studied and less well understood.&#13; &#13;Recently, the concept of the flat band, with a vanishing dispersion, has gained importance. Especially in electronic systems, many theories and experiments have proven that some structures such as kagome or honeycomb lattices hosts such flat bands with non-trivial topology. Even though a number of theories suggest that such dispersionless mode exist in magnonic bands under the framework of the Heisenberg spin model, few experiments indicate its existence. Not limited to these flat band effects, magnetic insulators can assume a variety of nontrivial topologies such as magnetic skyrmions. In this thesis, I investigate the highly frustrated magnetic system Y0.5Ca0.5BaCo4O7, where the kagome lattice could potentially lead to nontrivial thermal transport originated from its flat band. While we do not observe signatures of the flat band in thermal conductivity, the observed anomalous Hall effect in electrical transport and spin glass-like behavior suggest a complex magnetization-transport mechanism.&#13;&#13;Motivated by the rapid advancement of artificial inteligence, the application of machine learning into materials exploration is recently investigated. Using a graphical representation of crystallines orginally suggested in Crystal Graphical Convolutional Neural Network (CGCNN), we developed the ML-asssited method to explore magnetic compounds. Our machine learning model can, so far, distiguish ferromagnet or antiferromagnet systems with over 70% accuracy based only on structual/elemental information. Prospects of studying more complex magnets are described.</mods:abstract>
-                            <mods:language>
-                                <mods:languageTerm authority="rfc3066">en_US</mods:languageTerm>
-                            </mods:language>
-                            <mods:originInfo>
-                                <mods:publisher>Massachusetts Institute of Technology</mods:publisher>
-                            </mods:originInfo>
-                            <mods:accessCondition type="useAndReproduction">In Copyright - Educational Use Permitted</mods:accessCondition>
-                            <mods:titleInfo>
-                                <mods:title>Magneto-thermal Transport and Machine Learning-assisted Investigation of Magnetic Materials</mods:title>
-                            </mods:titleInfo>
-                            <mods:titleInfo>
-                                <mods:title type="alternative">A Slightly Different Title</mods:title>
-                            </mods:titleInfo>
-                            <mods:genre>Thesis</mods:genre>
-                            <mods:subject>
-                                <mods:topic>Metallurgy and Materials Science</mods:topic>
-                            </mods:subject>
-                            <mods:relatedItem type="series">MIT-CSAIL-TR-2018-016</mods:relatedItem>
-                            <mods:relatedItem type="host">Nature Communications</mods:relatedItem>
-                        </mods:mods>
-                    </xmlData>
-                </mdWrap>
-            </dmdSec>
-            <amdSec ID="FO_1721.1_142832_1">
-                <techMD ID="TECH_O_1721.1_142832_1">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>12351827</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>application/pdf</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
+<records>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <header>
+            <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
+            <datestamp>2022-06-01T03:46:27Z</datestamp>
+            <setSpec>com_1721.1_7582</setSpec>
+            <setSpec>hdl_1721.1_7582</setSpec>
+            <setSpec>com_1721.1_7581</setSpec>
+            <setSpec>hdl_1721.1_7581</setSpec>
+            <setSpec>col_1721.1_131023</setSpec>
+            <setSpec>hdl_1721.1_131023</setSpec>
+        </header>
+        <metadata>
+            <mets xmlns="http://www.loc.gov/METS/"
+                xmlns:doc="http://www.lyncode.com/xoai"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
+                <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
+                    <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
+                        <name>mit-6</name>
+                    </agent>
+                </metsHdr>
+                <dmdSec ID="DMD_1721.1_142832">
+                    <mdWrap MDTYPE="MODS">
+                        <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                            <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm type="text">advisor</mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart>Checkelsky, Joseph</mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm type="text">author</mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart>Tatsumi, Yuki</mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm type="text">department</mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart>Massachusetts Institute of Technology. Department of Physics</mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:namePart>Smith, Susie Q.</mods:namePart>
+                                </mods:name>
+                                <mods:extension>
+                                    <mods:dateAccessioned encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAccessioned>
+                                </mods:extension>
+                                <mods:extension>
+                                    <mods:dateAvailable encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAvailable>
+                                </mods:extension>
+                                <mods:originInfo>
+                                    <mods:dateIssued encoding="iso8601">2021-09</mods:dateIssued>
+                                </mods:originInfo>
+                                <mods:identifier type="citation">Tatsumi, Yuki. "Magneto-thermal Transport and Machine Learning-assisted Investigation of Magnetic Materials." Massachusetts Institute of Technology © 2022.</mods:identifier>
+                                <mods:identifier type="uri">https://hdl.handle.net/1721.1/142832</mods:identifier>
+                                <mods:abstract>Heat is carried by different types quasiparticles in crystals, including phonons, charge carriers, and magnetic excitations. In most materials, thermal transport can be understood as the flow of phonons and charge carriers; magnetic heat flow is less well-studied and less well understood.&#13; &#13;Recently, the concept of the flat band, with a vanishing dispersion, has gained importance. Especially in electronic systems, many theories and experiments have proven that some structures such as kagome or honeycomb lattices hosts such flat bands with non-trivial topology. Even though a number of theories suggest that such dispersionless mode exist in magnonic bands under the framework of the Heisenberg spin model, few experiments indicate its existence. Not limited to these flat band effects, magnetic insulators can assume a variety of nontrivial topologies such as magnetic skyrmions. In this thesis, I investigate the highly frustrated magnetic system Y0.5Ca0.5BaCo4O7, where the kagome lattice could potentially lead to nontrivial thermal transport originated from its flat band. While we do not observe signatures of the flat band in thermal conductivity, the observed anomalous Hall effect in electrical transport and spin glass-like behavior suggest a complex magnetization-transport mechanism.&#13;&#13;Motivated by the rapid advancement of artificial inteligence, the application of machine learning into materials exploration is recently investigated. Using a graphical representation of crystallines orginally suggested in Crystal Graphical Convolutional Neural Network (CGCNN), we developed the ML-asssited method to explore magnetic compounds. Our machine learning model can, so far, distiguish ferromagnet or antiferromagnet systems with over 70% accuracy based only on structual/elemental information. Prospects of studying more complex magnets are described.</mods:abstract>
+                                <mods:language>
+                                    <mods:languageTerm authority="rfc3066">en_US</mods:languageTerm>
+                                </mods:language>
+                                <mods:originInfo>
+                                    <mods:publisher>Massachusetts Institute of Technology</mods:publisher>
+                                </mods:originInfo>
+                                <mods:accessCondition type="useAndReproduction">In Copyright - Educational Use Permitted</mods:accessCondition>
+                                <mods:titleInfo>
+                                    <mods:title>Magneto-thermal Transport and Machine Learning-assisted Investigation of Magnetic Materials</mods:title>
+                                </mods:titleInfo>
+                                <mods:titleInfo>
+                                    <mods:title type="alternative">A Slightly Different Title</mods:title>
+                                </mods:titleInfo>
+                                <mods:genre>Thesis</mods:genre>
+                                <mods:subject>
+                                    <mods:topic>Metallurgy and Materials Science</mods:topic>
+                                </mods:subject>
+                                <mods:relatedItem type="series">MIT-CSAIL-TR-2018-016</mods:relatedItem>
+                                <mods:relatedItem type="host">Nature Communications</mods:relatedItem>
+                            </mods:mods>
                         </xmlData>
                     </mdWrap>
-                </techMD>
-            </amdSec>
-            <amdSec ID="FT_1721.1_142832_2">
-                <techMD ID="TECH_T_1721.1_142832_2">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>76618</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>text/plain</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
-                        </xmlData>
-                    </mdWrap>
-                </techMD>
-            </amdSec>
-            <fileSec>
-                <fileGrp USE="ORIGINAL">
-                    <file ID="BITSTREAM_ORIGINAL_1721.1_142832_1" MIMETYPE="application/pdf" SEQ="1" SIZE="12351827" CHECKSUM="3a06f8863f4dfb2f1ab22607007c34e7" CHECKSUMTYPE="MD5" ADMID="FO_1721.1_142832_1" GROUPID="GROUP_BITSTREAM_1721.1_142832_1">
-                        <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf"/>
-                    </file>
-                </fileGrp>
-                <fileGrp USE="TEXT">
-                    <file ID="BITSTREAM_TEXT_1721.1_142832_2" MIMETYPE="text/plain" SEQ="2" SIZE="76618" CHECKSUM="588f139172959b8eee0a67e406ef4016" CHECKSUMTYPE="MD5" ADMID="FT_1721.1_142832_2" GROUPID="GROUP_BITSTREAM_1721.1_142832_2">
-                        <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt"/>
-                    </file>
-                </fileGrp>
-            </fileSec>
-            <structMap TYPE="LOGICAL" LABEL="DSpace Object">
-                <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
-                    <div TYPE="DSpace BITSTREAM">
-                        <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                </dmdSec>
+                <amdSec ID="FO_1721.1_142832_1">
+                    <techMD ID="TECH_O_1721.1_142832_1">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>12351827</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>application/pdf</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <amdSec ID="FT_1721.1_142832_2">
+                    <techMD ID="TECH_T_1721.1_142832_2">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>76618</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>text/plain</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <fileSec>
+                    <fileGrp USE="ORIGINAL">
+                        <file ID="BITSTREAM_ORIGINAL_1721.1_142832_1" MIMETYPE="application/pdf" SEQ="1" SIZE="12351827" CHECKSUM="3a06f8863f4dfb2f1ab22607007c34e7" CHECKSUMTYPE="MD5" ADMID="FO_1721.1_142832_1" GROUPID="GROUP_BITSTREAM_1721.1_142832_1">
+                            <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf"/>
+                        </file>
+                    </fileGrp>
+                    <fileGrp USE="TEXT">
+                        <file ID="BITSTREAM_TEXT_1721.1_142832_2" MIMETYPE="text/plain" SEQ="2" SIZE="76618" CHECKSUM="588f139172959b8eee0a67e406ef4016" CHECKSUMTYPE="MD5" ADMID="FT_1721.1_142832_2" GROUPID="GROUP_BITSTREAM_1721.1_142832_2">
+                            <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt"/>
+                        </file>
+                    </fileGrp>
+                </fileSec>
+                <structMap TYPE="LOGICAL" LABEL="DSpace Object">
+                    <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
+                        <div TYPE="DSpace BITSTREAM">
+                            <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                        </div>
                     </div>
-                </div>
-            </structMap>
-        </mets>
-    </metadata>
-</record>
+                </structMap>
+            </mets>
+        </metadata>
+    </record>
+</records>

--- a/tests/fixtures/dspace/dspace_mets_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/dspace/dspace_mets_record_attribute_and_subfield_variations.xml
@@ -1,196 +1,198 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<record xmlns="http://www.openarchives.org/OAI/2.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <header>
-        <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
-        <datestamp>2022-06-01T03:46:27Z</datestamp>
-        <setSpec>com_1721.1_7582</setSpec>
-        <setSpec>hdl_1721.1_7582</setSpec>
-        <setSpec>com_1721.1_7581</setSpec>
-        <setSpec>hdl_1721.1_7581</setSpec>
-        <setSpec>col_1721.1_131023</setSpec>
-        <setSpec>hdl_1721.1_131023</setSpec>
-    </header>
-    <metadata>
-        <mets xmlns="http://www.loc.gov/METS/"
-            xmlns:doc="http://www.lyncode.com/xoai"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
-            <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
-                <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
-                    <name>mit-6</name>
-                </agent>
-            </metsHdr>
-            <dmdSec ID="DMD_1721.1_142832">
-                <mdWrap MDTYPE="MODS">
-                    <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                        <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                            <mods:name></mods:name>
-                            <mods:name>
-                                <mods:namePart></mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role></mods:role>
-                                <mods:namePart></mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm></mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart></mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm>advisor</mods:roleTerm>
-                                </mods:role>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm>advisor</mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart></mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:namePart>One, Author</mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role></mods:role>
-                                <mods:namePart>Two, Author</mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm></mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart>Three, Author</mods:namePart>
-                            </mods:name>
-                            <mods:extension>
-                                <mods:dateAccessioned encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAccessioned>
-                            </mods:extension>
-                            <mods:extension>
-                                <mods:dateAvailable encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAvailable>
-                            </mods:extension>
-                            <mods:originInfo>
-                                <mods:dateIssued encoding="iso8601">2021-09</mods:dateIssued>
-                            </mods:originInfo>
-                            <mods:identifier></mods:identifier>
-                            <mods:identifier>ID-no-type</mods:identifier>
-                            <mods:identifier type=""></mods:identifier>
-                            <mods:identifier type="">ID-blank-type</mods:identifier>
-                            <mods:identifier type="citation"></mods:identifier>
-                            <mods:identifier type="other"></mods:identifier>
-                            <mods:identifier type="uri"></mods:identifier>
-                            <mods:identifier type="uri">https://link-to-item</mods:identifier>
-                            <mods:accessCondition></mods:accessCondition>
-                            <mods:accessCondition>Access condition no type</mods:accessCondition>
-                            <mods:accessCondition type=""></mods:accessCondition>
-                            <mods:accessCondition type="">Access condition blank type</mods:accessCondition>
-                            <mods:titleInfo>
-                                <mods:title></mods:title>
-                            </mods:titleInfo>
-                            <mods:titleInfo>
-                                <mods:title type=""></mods:title>
-                            </mods:titleInfo>
-                            <mods:titleInfo>
-                                <mods:title type="">Title with Blank Type</mods:title>
-                            </mods:titleInfo>
-                            <mods:titleInfo>
-                                <mods:title type="No title"></mods:title>
-                            </mods:titleInfo>
-                            <mods:titleInfo>
-                                <mods:title type="">Second Title with Blank Type</mods:title>
-                            </mods:titleInfo>
-                            <mods:genre>Thesis</mods:genre>
-                            <mods:relatedItem></mods:relatedItem>
-                            <mods:relatedItem>Related item no type</mods:relatedItem>
-                            <mods:relatedItem type=""></mods:relatedItem>
-                            <mods:relatedItem type="">Related item blank type</mods:relatedItem>
-                            <mods:relatedItem type="series"></mods:relatedItem>
-                            <mods:relatedItem type="other"></mods:relatedItem>
-                        </mods:mods>
-                    </xmlData>
-                </mdWrap>
-            </dmdSec>
-            <amdSec ID="FO_1721.1_142832_1">
-                <techMD ID="TECH_O_1721.1_142832_1">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>12351827</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>application/pdf</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
+<records>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <header>
+            <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
+            <datestamp>2022-06-01T03:46:27Z</datestamp>
+            <setSpec>com_1721.1_7582</setSpec>
+            <setSpec>hdl_1721.1_7582</setSpec>
+            <setSpec>com_1721.1_7581</setSpec>
+            <setSpec>hdl_1721.1_7581</setSpec>
+            <setSpec>col_1721.1_131023</setSpec>
+            <setSpec>hdl_1721.1_131023</setSpec>
+        </header>
+        <metadata>
+            <mets xmlns="http://www.loc.gov/METS/"
+                xmlns:doc="http://www.lyncode.com/xoai"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
+                <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
+                    <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
+                        <name>mit-6</name>
+                    </agent>
+                </metsHdr>
+                <dmdSec ID="DMD_1721.1_142832">
+                    <mdWrap MDTYPE="MODS">
+                        <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                            <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                                <mods:name></mods:name>
+                                <mods:name>
+                                    <mods:namePart></mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role></mods:role>
+                                    <mods:namePart></mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm></mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart></mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm>advisor</mods:roleTerm>
+                                    </mods:role>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm>advisor</mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart></mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:namePart>One, Author</mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role></mods:role>
+                                    <mods:namePart>Two, Author</mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm></mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart>Three, Author</mods:namePart>
+                                </mods:name>
+                                <mods:extension>
+                                    <mods:dateAccessioned encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAccessioned>
+                                </mods:extension>
+                                <mods:extension>
+                                    <mods:dateAvailable encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAvailable>
+                                </mods:extension>
+                                <mods:originInfo>
+                                    <mods:dateIssued encoding="iso8601">2021-09</mods:dateIssued>
+                                </mods:originInfo>
+                                <mods:identifier></mods:identifier>
+                                <mods:identifier>ID-no-type</mods:identifier>
+                                <mods:identifier type=""></mods:identifier>
+                                <mods:identifier type="">ID-blank-type</mods:identifier>
+                                <mods:identifier type="citation"></mods:identifier>
+                                <mods:identifier type="other"></mods:identifier>
+                                <mods:identifier type="uri"></mods:identifier>
+                                <mods:identifier type="uri">https://link-to-item</mods:identifier>
+                                <mods:accessCondition></mods:accessCondition>
+                                <mods:accessCondition>Access condition no type</mods:accessCondition>
+                                <mods:accessCondition type=""></mods:accessCondition>
+                                <mods:accessCondition type="">Access condition blank type</mods:accessCondition>
+                                <mods:titleInfo>
+                                    <mods:title></mods:title>
+                                </mods:titleInfo>
+                                <mods:titleInfo>
+                                    <mods:title type=""></mods:title>
+                                </mods:titleInfo>
+                                <mods:titleInfo>
+                                    <mods:title type="">Title with Blank Type</mods:title>
+                                </mods:titleInfo>
+                                <mods:titleInfo>
+                                    <mods:title type="No title"></mods:title>
+                                </mods:titleInfo>
+                                <mods:titleInfo>
+                                    <mods:title type="">Second Title with Blank Type</mods:title>
+                                </mods:titleInfo>
+                                <mods:genre>Thesis</mods:genre>
+                                <mods:relatedItem></mods:relatedItem>
+                                <mods:relatedItem>Related item no type</mods:relatedItem>
+                                <mods:relatedItem type=""></mods:relatedItem>
+                                <mods:relatedItem type="">Related item blank type</mods:relatedItem>
+                                <mods:relatedItem type="series"></mods:relatedItem>
+                                <mods:relatedItem type="other"></mods:relatedItem>
+                            </mods:mods>
                         </xmlData>
                     </mdWrap>
-                </techMD>
-            </amdSec>
-            <amdSec ID="FT_1721.1_142832_2">
-                <techMD ID="TECH_T_1721.1_142832_2">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>76618</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>text/plain</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
-                        </xmlData>
-                    </mdWrap>
-                </techMD>
-            </amdSec>
-            <fileSec>
-                <fileGrp USE="ORIGINAL">
-                </fileGrp>
-                <fileGrp USE="ORIGINAL">
-                    <file>File no mimetype</file>
-                </fileGrp>
-                <fileGrp USE="ORIGINAL" MIMETYPE="">
-                    <file>File blank mimetype</file>
-                </fileGrp>
-                <fileGrp USE="ORIGINAL">
-                    <file MIMETYPE="application/pdf"></file>
-                </fileGrp>
-                <fileGrp USE="OTHER"></fileGrp>
-            </fileSec>
-            <structMap TYPE="LOGICAL" LABEL="DSpace Object">
-                <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
-                    <div TYPE="DSpace BITSTREAM">
-                        <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                </dmdSec>
+                <amdSec ID="FO_1721.1_142832_1">
+                    <techMD ID="TECH_O_1721.1_142832_1">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>12351827</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>application/pdf</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <amdSec ID="FT_1721.1_142832_2">
+                    <techMD ID="TECH_T_1721.1_142832_2">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>76618</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>text/plain</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <fileSec>
+                    <fileGrp USE="ORIGINAL">
+                    </fileGrp>
+                    <fileGrp USE="ORIGINAL">
+                        <file>File no mimetype</file>
+                    </fileGrp>
+                    <fileGrp USE="ORIGINAL" MIMETYPE="">
+                        <file>File blank mimetype</file>
+                    </fileGrp>
+                    <fileGrp USE="ORIGINAL">
+                        <file MIMETYPE="application/pdf"></file>
+                    </fileGrp>
+                    <fileGrp USE="OTHER"></fileGrp>
+                </fileSec>
+                <structMap TYPE="LOGICAL" LABEL="DSpace Object">
+                    <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
+                        <div TYPE="DSpace BITSTREAM">
+                            <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                        </div>
                     </div>
-                </div>
-            </structMap>
-        </mets>
-    </metadata>
-</record>
+                </structMap>
+            </mets>
+        </metadata>
+    </record>
+</records>

--- a/tests/fixtures/dspace/dspace_mets_record_optional_fields_blank.xml
+++ b/tests/fixtures/dspace/dspace_mets_record_optional_fields_blank.xml
@@ -1,169 +1,171 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<record xmlns="http://www.openarchives.org/OAI/2.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <header>
-        <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
-        <datestamp>2022-06-01T03:46:27Z</datestamp>
-        <setSpec>com_1721.1_7582</setSpec>
-        <setSpec>hdl_1721.1_7582</setSpec>
-        <setSpec>com_1721.1_7581</setSpec>
-        <setSpec>hdl_1721.1_7581</setSpec>
-        <setSpec>col_1721.1_131023</setSpec>
-        <setSpec>hdl_1721.1_131023</setSpec>
-    </header>
-    <metadata>
-        <mets xmlns="http://www.loc.gov/METS/"
-            xmlns:doc="http://www.lyncode.com/xoai"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
-            <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
-                <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
-                    <name>mit-6</name>
-                </agent>
-            </metsHdr>
-            <dmdSec ID="DMD_1721.1_142832">
-                <mdWrap MDTYPE="MODS">
-                    <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                        <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm type="text"></mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart></mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:role>
-                                    <mods:roleTerm type="text">author</mods:roleTerm>
-                                </mods:role>
-                                <mods:namePart></mods:namePart>
-                            </mods:name>
-                            <mods:name>
-                                <mods:roleTerm/>
-                                <mods:namePart/>
-                            </mods:name>
-                            <mods:name/>
-                            <mods:extension>
-                                <mods:dateAccessioned encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAccessioned>
-                            </mods:extension>
-                            <mods:extension>
-                                <mods:dateAvailable encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAvailable>
-                            </mods:extension>
-                            <mods:originInfo>
-                                <mods:dateIssued encoding="iso8601"></mods:dateIssued>
-                            </mods:originInfo>
-                            <mods:identifier type="citation"></mods:identifier>
-                            <mods:identifier type="uri"/>
-                            <mods:identifier/>
-                            <mods:abstract></mods:abstract>
-                            <mods:language>
-                                <mods:languageTerm authority="rfc3066"/>
-                            </mods:language>
-                            <mods:language/>
-                            <mods:originInfo>
-                                <mods:publisher></mods:publisher>
-                            </mods:originInfo>
-                            <mods:accessCondition type="useAndReproduction"></mods:accessCondition>
-                            <mods:accessCondition/>
-                            <mods:titleInfo>
-                                <mods:title></mods:title>
-                            </mods:titleInfo>
-                            <mods:titleInfo>
-                                <mods:title type="alternative"></mods:title>
-                            </mods:titleInfo>
-                            <mods:titleInfo></mods:titleInfo>
-                            <mods:genre></mods:genre>
-                            <mods:subject>
-                                <mods:topic/>
-                            </mods:subject>
-                            <mods:subject/>
-                            <mods:relatedItem type="series"></mods:relatedItem>
-                            <mods:relatedItem type="host"></mods:relatedItem>
-                            <mods:relatedItem></mods:relatedItem>
-                        </mods:mods>
-                    </xmlData>
-                </mdWrap>
-            </dmdSec>
-            <amdSec ID="FO_1721.1_142832_1">
-                <techMD ID="TECH_O_1721.1_142832_1">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>12351827</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>application/pdf</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
+<records>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <header>
+            <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
+            <datestamp>2022-06-01T03:46:27Z</datestamp>
+            <setSpec>com_1721.1_7582</setSpec>
+            <setSpec>hdl_1721.1_7582</setSpec>
+            <setSpec>com_1721.1_7581</setSpec>
+            <setSpec>hdl_1721.1_7581</setSpec>
+            <setSpec>col_1721.1_131023</setSpec>
+            <setSpec>hdl_1721.1_131023</setSpec>
+        </header>
+        <metadata>
+            <mets xmlns="http://www.loc.gov/METS/"
+                xmlns:doc="http://www.lyncode.com/xoai"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
+                <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
+                    <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
+                        <name>mit-6</name>
+                    </agent>
+                </metsHdr>
+                <dmdSec ID="DMD_1721.1_142832">
+                    <mdWrap MDTYPE="MODS">
+                        <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                            <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm type="text"></mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart></mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:role>
+                                        <mods:roleTerm type="text">author</mods:roleTerm>
+                                    </mods:role>
+                                    <mods:namePart></mods:namePart>
+                                </mods:name>
+                                <mods:name>
+                                    <mods:roleTerm/>
+                                    <mods:namePart/>
+                                </mods:name>
+                                <mods:name/>
+                                <mods:extension>
+                                    <mods:dateAccessioned encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAccessioned>
+                                </mods:extension>
+                                <mods:extension>
+                                    <mods:dateAvailable encoding="iso8601">2022-05-31T13:31:20Z</mods:dateAvailable>
+                                </mods:extension>
+                                <mods:originInfo>
+                                    <mods:dateIssued encoding="iso8601"></mods:dateIssued>
+                                </mods:originInfo>
+                                <mods:identifier type="citation"></mods:identifier>
+                                <mods:identifier type="uri"/>
+                                <mods:identifier/>
+                                <mods:abstract></mods:abstract>
+                                <mods:language>
+                                    <mods:languageTerm authority="rfc3066"/>
+                                </mods:language>
+                                <mods:language/>
+                                <mods:originInfo>
+                                    <mods:publisher></mods:publisher>
+                                </mods:originInfo>
+                                <mods:accessCondition type="useAndReproduction"></mods:accessCondition>
+                                <mods:accessCondition/>
+                                <mods:titleInfo>
+                                    <mods:title></mods:title>
+                                </mods:titleInfo>
+                                <mods:titleInfo>
+                                    <mods:title type="alternative"></mods:title>
+                                </mods:titleInfo>
+                                <mods:titleInfo></mods:titleInfo>
+                                <mods:genre></mods:genre>
+                                <mods:subject>
+                                    <mods:topic/>
+                                </mods:subject>
+                                <mods:subject/>
+                                <mods:relatedItem type="series"></mods:relatedItem>
+                                <mods:relatedItem type="host"></mods:relatedItem>
+                                <mods:relatedItem></mods:relatedItem>
+                            </mods:mods>
                         </xmlData>
                     </mdWrap>
-                </techMD>
-            </amdSec>
-            <amdSec ID="FT_1721.1_142832_2">
-                <techMD ID="TECH_T_1721.1_142832_2">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>76618</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>text/plain</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
-                        </xmlData>
-                    </mdWrap>
-                </techMD>
-            </amdSec>
-            <fileSec>
-                <fileGrp USE="ORIGINAL">
-                    <file ID="BITSTREAM_ORIGINAL_1721.1_142832_1" SEQ="1" SIZE="12351827" CHECKSUM="3a06f8863f4dfb2f1ab22607007c34e7" CHECKSUMTYPE="MD5" ADMID="FO_1721.1_142832_1" GROUPID="GROUP_BITSTREAM_1721.1_142832_1">
-                        <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf"/>
-                    </file>
-                </fileGrp>
-                <fileGrp USE="ORIGINAL">
-                </fileGrp>
-                <fileGrp USE="TEXT">
-                    <file ID="BITSTREAM_TEXT_1721.1_142832_2" MIMETYPE="text/plain" SEQ="2" SIZE="76618" CHECKSUM="588f139172959b8eee0a67e406ef4016" CHECKSUMTYPE="MD5" ADMID="FT_1721.1_142832_2" GROUPID="GROUP_BITSTREAM_1721.1_142832_2">
-                        <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt"/>
-                    </file>
-                </fileGrp>
-            </fileSec>
-            <structMap TYPE="LOGICAL" LABEL="DSpace Object">
-                <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
-                    <div TYPE="DSpace BITSTREAM">
-                        <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                </dmdSec>
+                <amdSec ID="FO_1721.1_142832_1">
+                    <techMD ID="TECH_O_1721.1_142832_1">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>12351827</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>application/pdf</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <amdSec ID="FT_1721.1_142832_2">
+                    <techMD ID="TECH_T_1721.1_142832_2">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>76618</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>text/plain</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <fileSec>
+                    <fileGrp USE="ORIGINAL">
+                        <file ID="BITSTREAM_ORIGINAL_1721.1_142832_1" SEQ="1" SIZE="12351827" CHECKSUM="3a06f8863f4dfb2f1ab22607007c34e7" CHECKSUMTYPE="MD5" ADMID="FO_1721.1_142832_1" GROUPID="GROUP_BITSTREAM_1721.1_142832_1">
+                            <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf"/>
+                        </file>
+                    </fileGrp>
+                    <fileGrp USE="ORIGINAL">
+                    </fileGrp>
+                    <fileGrp USE="TEXT">
+                        <file ID="BITSTREAM_TEXT_1721.1_142832_2" MIMETYPE="text/plain" SEQ="2" SIZE="76618" CHECKSUM="588f139172959b8eee0a67e406ef4016" CHECKSUMTYPE="MD5" ADMID="FT_1721.1_142832_2" GROUPID="GROUP_BITSTREAM_1721.1_142832_2">
+                            <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt"/>
+                        </file>
+                    </fileGrp>
+                </fileSec>
+                <structMap TYPE="LOGICAL" LABEL="DSpace Object">
+                    <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
+                        <div TYPE="DSpace BITSTREAM">
+                            <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                        </div>
                     </div>
-                </div>
-            </structMap>
-        </mets>
-    </metadata>
-</record>
+                </structMap>
+            </mets>
+        </metadata>
+    </record>
+</records>

--- a/tests/fixtures/dspace/dspace_mets_record_optional_fields_missing.xml
+++ b/tests/fixtures/dspace/dspace_mets_record_optional_fields_missing.xml
@@ -1,111 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<record xmlns="http://www.openarchives.org/OAI/2.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <header>
-        <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
-        <datestamp>2022-06-01T03:46:27Z</datestamp>
-        <setSpec>com_1721.1_7582</setSpec>
-        <setSpec>hdl_1721.1_7582</setSpec>
-        <setSpec>com_1721.1_7581</setSpec>
-        <setSpec>hdl_1721.1_7581</setSpec>
-        <setSpec>col_1721.1_131023</setSpec>
-        <setSpec>hdl_1721.1_131023</setSpec>
-    </header>
-    <metadata>
-        <mets xmlns="http://www.loc.gov/METS/"
-            xmlns:doc="http://www.lyncode.com/xoai"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
-            <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
-                <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
-                    <name>mit-6</name>
-                </agent>
-            </metsHdr>
-            <dmdSec ID="DMD_1721.1_142832">
-                <mdWrap MDTYPE="MODS">
-                    <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                        <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
-                            <mods:titleInfo>
-                                <mods:title></mods:title>
-                            </mods:titleInfo>
-                        </mods:mods>
-                    </xmlData>
-                </mdWrap>
-            </dmdSec>
-            <amdSec ID="FO_1721.1_142832_1">
-                <techMD ID="TECH_O_1721.1_142832_1">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>12351827</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>application/pdf</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
+<records>
+    <record xmlns="http://www.openarchives.org/OAI/2.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <header>
+            <identifier>oai:dspace.mit.edu:1721.1/142832</identifier>
+            <datestamp>2022-06-01T03:46:27Z</datestamp>
+            <setSpec>com_1721.1_7582</setSpec>
+            <setSpec>hdl_1721.1_7582</setSpec>
+            <setSpec>com_1721.1_7581</setSpec>
+            <setSpec>hdl_1721.1_7581</setSpec>
+            <setSpec>col_1721.1_131023</setSpec>
+            <setSpec>hdl_1721.1_131023</setSpec>
+        </header>
+        <metadata>
+            <mets xmlns="http://www.loc.gov/METS/"
+                xmlns:doc="http://www.lyncode.com/xoai"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd" PROFILE="DSpace METS SIP Profile 1.0" TYPE="DSpace ITEM" ID="&#10;&#9;&#9;&#9;&#9;DSpace_ITEM_1721.1-142832" OBJID="&#10;&#9;&#9;&#9;&#9;hdl:1721.1/142832">
+                <metsHdr CREATEDATE="2022-06-06T14:02:17Z">
+                    <agent TYPE="ORGANIZATION" ROLE="CUSTODIAN">
+                        <name>mit-6</name>
+                    </agent>
+                </metsHdr>
+                <dmdSec ID="DMD_1721.1_142832">
+                    <mdWrap MDTYPE="MODS">
+                        <xmlData xmlns:mods="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                            <mods:mods xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                                <mods:titleInfo>
+                                    <mods:title></mods:title>
+                                </mods:titleInfo>
+                            </mods:mods>
                         </xmlData>
                     </mdWrap>
-                </techMD>
-            </amdSec>
-            <amdSec ID="FT_1721.1_142832_2">
-                <techMD ID="TECH_T_1721.1_142832_2">
-                    <mdWrap MDTYPE="PREMIS">
-                        <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
-                            <premis:premis>
-                                <premis:object>
-                                    <premis:objectIdentifier>
-                                        <premis:objectIdentifierType>URL</premis:objectIdentifierType>
-                                        <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
-                                    </premis:objectIdentifier>
-                                    <premis:objectCategory>File</premis:objectCategory>
-                                    <premis:objectCharacteristics>
-                                        <premis:fixity>
-                                            <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
-                                            <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
-                                        </premis:fixity>
-                                        <premis:size>76618</premis:size>
-                                        <premis:format>
-                                            <premis:formatDesignation>
-                                                <premis:formatName>text/plain</premis:formatName>
-                                            </premis:formatDesignation>
-                                        </premis:format>
-                                    </premis:objectCharacteristics>
-                                    <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
-                                </premis:object>
-                            </premis:premis>
-                        </xmlData>
-                    </mdWrap>
-                </techMD>
-            </amdSec>
-            <fileSec>
-                <fileGrp USE="TEXT">
-                    <file ID="BITSTREAM_TEXT_1721.1_142832_2" MIMETYPE="text/plain" SEQ="2" SIZE="76618" CHECKSUM="588f139172959b8eee0a67e406ef4016" CHECKSUMTYPE="MD5" ADMID="FT_1721.1_142832_2" GROUPID="GROUP_BITSTREAM_1721.1_142832_2">
-                        <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt"/>
-                    </file>
-                </fileGrp>
-            </fileSec>
-            <structMap TYPE="LOGICAL" LABEL="DSpace Object">
-                <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
-                    <div TYPE="DSpace BITSTREAM">
-                        <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                </dmdSec>
+                <amdSec ID="FO_1721.1_142832_1">
+                    <techMD ID="TECH_O_1721.1_142832_1">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/1/tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>3a06f8863f4dfb2f1ab22607007c34e7</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>12351827</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>application/pdf</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <amdSec ID="FT_1721.1_142832_2">
+                    <techMD ID="TECH_T_1721.1_142832_2">
+                        <mdWrap MDTYPE="PREMIS">
+                            <xmlData xmlns:premis="http://www.loc.gov/standards/premis" xsi:schemaLocation="http://www.loc.gov/standards/premis http://www.loc.gov/standards/premis/PREMIS-v1-0.xsd">
+                                <premis:premis>
+                                    <premis:object>
+                                        <premis:objectIdentifier>
+                                            <premis:objectIdentifierType>URL</premis:objectIdentifierType>
+                                            <premis:objectIdentifierValue>https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:objectIdentifierValue>
+                                        </premis:objectIdentifier>
+                                        <premis:objectCategory>File</premis:objectCategory>
+                                        <premis:objectCharacteristics>
+                                            <premis:fixity>
+                                                <premis:messageDigestAlgorithm>MD5</premis:messageDigestAlgorithm>
+                                                <premis:messageDigest>588f139172959b8eee0a67e406ef4016</premis:messageDigest>
+                                            </premis:fixity>
+                                            <premis:size>76618</premis:size>
+                                            <premis:format>
+                                                <premis:formatDesignation>
+                                                    <premis:formatName>text/plain</premis:formatName>
+                                                </premis:formatDesignation>
+                                            </premis:format>
+                                        </premis:objectCharacteristics>
+                                        <premis:originalName>tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt</premis:originalName>
+                                    </premis:object>
+                                </premis:premis>
+                            </xmlData>
+                        </mdWrap>
+                    </techMD>
+                </amdSec>
+                <fileSec>
+                    <fileGrp USE="TEXT">
+                        <file ID="BITSTREAM_TEXT_1721.1_142832_2" MIMETYPE="text/plain" SEQ="2" SIZE="76618" CHECKSUM="588f139172959b8eee0a67e406ef4016" CHECKSUMTYPE="MD5" ADMID="FT_1721.1_142832_2" GROUPID="GROUP_BITSTREAM_1721.1_142832_2">
+                            <FLocat xlink:type="simple" LOCTYPE="URL" xlink:href="https://dspace.mit.edu/bitstream/1721.1/142832/2/tatsumi-yukit-sm-physisc-2021-thesis.pdf.txt"/>
+                        </file>
+                    </fileGrp>
+                </fileSec>
+                <structMap TYPE="LOGICAL" LABEL="DSpace Object">
+                    <div TYPE="DSpace Object Contents" ADMID="DMD_1721.1_142832">
+                        <div TYPE="DSpace BITSTREAM">
+                            <fptr FILEID="BITSTREAM_ORIGINAL_1721.1_142832_1"/>
+                        </div>
                     </div>
-                </div>
-            </structMap>
-        </mets>
-    </metadata>
-</record>
+                </structMap>
+            </mets>
+        </metadata>
+    </record>
+</records>

--- a/tests/sources/xml/test_datacite.py
+++ b/tests/sources/xml/test_datacite.py
@@ -1,21 +1,6 @@
 from bs4 import BeautifulSoup
 
-from transmogrifier.models import (
-    AlternateTitle,
-    Contributor,
-    Date,
-    DateRange,
-    Funder,
-    Identifier,
-    Link,
-    Location,
-    Note,
-    Publisher,
-    RelatedItem,
-    Rights,
-    Subject,
-    TimdexRecord,
-)
+import transmogrifier.models as timdex
 from transmogrifier.sources.xml.datacite import Datacite
 
 
@@ -44,7 +29,7 @@ def create_datacite_source_record_stub(xml_insert: str = "") -> BeautifulSoup:
 def test_datacite_transform_with_all_fields_transforms_correctly(
     datacite_record_all_fields,
 ):
-    assert next(datacite_record_all_fields) == TimdexRecord(
+    assert next(datacite_record_all_fields) == timdex.TimdexRecord(
         citation=(
             "Banerji, Rukmini, Berry, James, Shotland, Marc "
             "(2017): The Impact of Maternal Literacy and Participation Programs. Harvard "
@@ -55,30 +40,30 @@ def test_datacite_transform_with_all_fields_transforms_correctly(
         timdex_record_id="cool-repo:doi:10.7910-DVN-19PPE7",
         title="The Impact of Maternal Literacy and Participation Programs",
         alternate_titles=[
-            AlternateTitle(value="An Alternative Title", kind="AlternativeTitle"),
-            AlternateTitle(value="Baseline Data", kind="Subtitle"),
+            timdex.AlternateTitle(value="An Alternative Title", kind="AlternativeTitle"),
+            timdex.AlternateTitle(value="Baseline Data", kind="Subtitle"),
         ],
         content_type=["Dataset"],
         contributors=[
-            Contributor(
+            timdex.Contributor(
                 value="Banerji, Rukmini",
                 affiliation=["Pratham and ASER Centre"],
                 identifier=["https://orcid.org/0000-0000-0000-0000"],
                 kind="Creator",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Berry, James",
                 affiliation=["University of Delaware"],
                 identifier=["0000-0000-0000-0001"],
                 kind="Creator",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Shotland, Marc",
                 affiliation=["Abdul Latif Jameel Poverty Action Lab"],
                 identifier=["0000-0000-0000-0002"],
                 kind="Creator",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Banerji, Rukmini",
                 affiliation=["Pratham and ASER Centre"],
                 identifier=["https://orcid.org/0000-0000-0000-0000"],
@@ -86,16 +71,16 @@ def test_datacite_transform_with_all_fields_transforms_correctly(
             ),
         ],
         dates=[
-            Date(kind="Publication date", value="2017"),
-            Date(kind="Submitted", value="2017-02-27"),
-            Date(
+            timdex.Date(kind="Publication date", value="2017"),
+            timdex.Date(kind="Submitted", value="2017-02-27"),
+            timdex.Date(
                 kind="Updated",
                 note="This was updated on this date",
                 value="2019-06-24",
             ),
-            Date(
+            timdex.Date(
                 kind="Collected",
-                range=DateRange(gte="2007-01-01", lte="2007-02-28"),
+                range=timdex.DateRange(gte="2007-01-01", lte="2007-02-28"),
             ),
         ],
         edition="1.2",
@@ -114,7 +99,7 @@ def test_datacite_transform_with_all_fields_transforms_correctly(
         ],
         format="electronic resource",
         funding_information=[
-            Funder(
+            timdex.Funder(
                 funder_name="3ie, Nike Foundation",
                 funder_identifier="0987",
                 funder_identifier_type="Crossref FunderID",
@@ -123,13 +108,13 @@ def test_datacite_transform_with_all_fields_transforms_correctly(
             )
         ],
         identifiers=[
-            Identifier(value="10.7910/DVN/19PPE7", kind="DOI"),
-            Identifier(value="https://zenodo.org/record/5524465", kind="url"),
-            Identifier(value="1234567.5524464", kind="IsIdenticalTo"),
+            timdex.Identifier(value="10.7910/DVN/19PPE7", kind="DOI"),
+            timdex.Identifier(value="https://zenodo.org/record/5524465", kind="url"),
+            timdex.Identifier(value="1234567.5524464", kind="IsIdenticalTo"),
         ],
-        locations=[Location(value="A point on the globe")],
+        locations=[timdex.Location(value="A point on the globe")],
         links=[
-            Link(
+            timdex.Link(
                 url="https://example.com/doi:10.7910/DVN/19PPE7",
                 kind="Digital object URL",
                 text="Digital object URL",
@@ -137,41 +122,41 @@ def test_datacite_transform_with_all_fields_transforms_correctly(
         ],
         languages=["en_US"],
         notes=[
-            Note(value=["Survey Data"], kind="Datacite resource type"),
-            Note(value=["Stata, 13"], kind="TechnicalInfo"),
+            timdex.Note(value=["Survey Data"], kind="Datacite resource type"),
+            timdex.Note(value=["Stata, 13"], kind="TechnicalInfo"),
         ],
-        publishers=[Publisher(name="Harvard Dataverse")],
+        publishers=[timdex.Publisher(name="Harvard Dataverse")],
         related_items=[
-            RelatedItem(
+            timdex.RelatedItem(
                 relationship="IsCitedBy",
                 uri="https://doi.org/10.1257/app.20150390",
             ),
-            RelatedItem(
+            timdex.RelatedItem(
                 relationship="IsVersionOf",
                 uri="10.5281/zenodo.5524464",
             ),
-            RelatedItem(
+            timdex.RelatedItem(
                 relationship="Other",
                 uri="1234567.5524464",
             ),
-            RelatedItem(
+            timdex.RelatedItem(
                 relationship="IsPartOf",
                 uri="https://zenodo.org/communities/astronomy-general",
             ),
         ],
         rights=[
-            Rights(uri="info:eu-repo/semantics/openAccess"),
-            Rights(
+            timdex.Rights(uri="info:eu-repo/semantics/openAccess"),
+            timdex.Rights(
                 description="CC0 1.0",
                 uri="http://creativecommons.org/publicdomain/zero/1.0",
             ),
         ],
         subjects=[
-            Subject(
+            timdex.Subject(
                 value=["Social Sciences", "Educational materials"],
                 kind="Subject scheme not provided",
             ),
-            Subject(
+            timdex.Subject(
                 value=[
                     "Adult education, education inputs, field experiments",
                     "Education",
@@ -223,7 +208,7 @@ def test_datacite_transform_with_optional_fields_blank_transforms_correctly():
         "tests/fixtures/datacite/datacite_record_optional_fields_blank.xml"
     )
     output_records = Datacite("cool-repo", source_records)
-    assert next(output_records) == TimdexRecord(
+    assert next(output_records) == timdex.TimdexRecord(
         citation=("Title not provided. https://example.com/doi:10.7910/DVN/19PPE7"),
         source="A Cool Repository",
         source_link="https://example.com/doi:10.7910/DVN/19PPE7",
@@ -231,7 +216,7 @@ def test_datacite_transform_with_optional_fields_blank_transforms_correctly():
         title="Title not provided",
         format="electronic resource",
         links=[
-            Link(
+            timdex.Link(
                 url="https://example.com/doi:10.7910/DVN/19PPE7",
                 kind="Digital object URL",
                 text="Digital object URL",
@@ -246,7 +231,7 @@ def test_datacite_transform_with_optional_fields_missing_transforms_correctly():
         "tests/fixtures/datacite/datacite_record_optional_fields_missing.xml"
     )
     output_records = Datacite("cool-repo", source_records)
-    assert next(output_records) == TimdexRecord(
+    assert next(output_records) == timdex.TimdexRecord(
         citation=("Title not provided. https://example.com/doi:10.7910/DVN/19PPE7"),
         source="A Cool Repository",
         source_link="https://example.com/doi:10.7910/DVN/19PPE7",
@@ -254,7 +239,7 @@ def test_datacite_transform_with_optional_fields_missing_transforms_correctly():
         title="Title not provided",
         format="electronic resource",
         links=[
-            Link(
+            timdex.Link(
                 url="https://example.com/doi:10.7910/DVN/19PPE7",
                 kind="Digital object URL",
                 text="Digital object URL",
@@ -269,7 +254,7 @@ def test_datacite_with_attribute_and_subfield_variations_transforms_correctly():
         "tests/fixtures/datacite/datacite_record_attribute_and_subfield_variations.xml"
     )
     output_records = Datacite("cool-repo", source_records)
-    assert next(output_records) == TimdexRecord(
+    assert next(output_records) == timdex.TimdexRecord(
         citation=(
             "Creator, No affiliation no identifier, Creator, Blank affiliation blank "
             "identifier, Creator, Identifier no scheme, Creator, Identifier blank "
@@ -280,106 +265,112 @@ def test_datacite_with_attribute_and_subfield_variations_transforms_correctly():
         source_link="https://example.com/doi:10.7910/DVN/19PPE7",
         timdex_record_id="cool-repo:doi:10.7910-DVN-19PPE7",
         title="Title with Blank titleType",
-        alternate_titles=[AlternateTitle(value="A Second Title with Blank titleType")],
+        alternate_titles=[
+            timdex.AlternateTitle(value="A Second Title with Blank titleType")
+        ],
         content_type=["Not specified"],
         contributors=[
-            Contributor(value="Creator, No affiliation no identifier", kind="Creator"),
-            Contributor(
+            timdex.Contributor(
+                value="Creator, No affiliation no identifier", kind="Creator"
+            ),
+            timdex.Contributor(
                 value="Creator, Blank affiliation blank identifier", kind="Creator"
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Creator, Identifier no scheme",
                 identifier=["0000-0000-0000-0000"],
                 kind="Creator",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Creator, Identifier blank scheme",
                 identifier=["0000-0000-0000-0000"],
                 kind="Creator",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Creator, No identifier with identifier scheme",
                 kind="Creator",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Contributor, No affiliation no identifier no type",
                 kind="Not specified",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Contributor, Blank affiliation blank identifier blank type",
                 kind="Not specified",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Contributor, Identifier no scheme",
                 identifier=["0000-0000-0000-0000"],
                 kind="Not specified",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Contributor, Identifier blank scheme",
                 identifier=["0000-0000-0000-0000"],
                 kind="Not specified",
             ),
-            Contributor(
+            timdex.Contributor(
                 value="Contributor, No identifier with identifier scheme",
                 kind="Not specified",
             ),
         ],
         dates=[
-            Date(value="2020-01-01"),
-            Date(note="OTHER"),
-            Date(value="2020-01-02"),
+            timdex.Date(value="2020-01-01"),
+            timdex.Date(note="OTHER"),
+            timdex.Date(value="2020-01-02"),
         ],
         format="electronic resource",
         funding_information=[
-            Funder(funder_name="Funder name no identifier no award"),
-            Funder(funder_name="Funder name blank identifier blank award"),
-            Funder(funder_identifier="Funder identifier no type"),
-            Funder(funder_identifier="Funder identifier blank type"),
-            Funder(award_number="Funder award no uri"),
-            Funder(award_number="Funder award blank uri"),
-            Funder(award_uri="Funder award uri without string"),
+            timdex.Funder(funder_name="Funder name no identifier no award"),
+            timdex.Funder(funder_name="Funder name blank identifier blank award"),
+            timdex.Funder(funder_identifier="Funder identifier no type"),
+            timdex.Funder(funder_identifier="Funder identifier blank type"),
+            timdex.Funder(award_number="Funder award no uri"),
+            timdex.Funder(award_number="Funder award blank uri"),
+            timdex.Funder(award_uri="Funder award uri without string"),
         ],
         identifiers=[
-            Identifier(value="ID-blank-type", kind="Not specified"),
-            Identifier(value="alternate-ID-no-type", kind="Not specified"),
-            Identifier(value="alternate-ID-blank-type", kind="Not specified"),
-            Identifier(
+            timdex.Identifier(value="ID-blank-type", kind="Not specified"),
+            timdex.Identifier(value="alternate-ID-no-type", kind="Not specified"),
+            timdex.Identifier(value="alternate-ID-blank-type", kind="Not specified"),
+            timdex.Identifier(
                 value="Related ID relationType IsIdenticalTo no relationIdentifierType",
                 kind="IsIdenticalTo",
             ),
-            Identifier(
+            timdex.Identifier(
                 value="Related ID relationType IsIdenticalTo blank "
                 "relationIdentifierType",
                 kind="IsIdenticalTo",
             ),
         ],
         links=[
-            Link(
+            timdex.Link(
                 url="https://example.com/doi:10.7910/DVN/19PPE7",
                 kind="Digital object URL",
                 text="Digital object URL",
             )
         ],
         notes=[
-            Note(value=["Description no type"]),
-            Note(value=["Description blank type"]),
+            timdex.Note(value=["Description no type"]),
+            timdex.Note(value=["Description blank type"]),
         ],
         related_items=[
-            RelatedItem(
+            timdex.RelatedItem(
                 relationship="Not specified",
                 uri="Related ID no relationType no relatedIdentifierType",
             ),
-            RelatedItem(
+            timdex.RelatedItem(
                 relationship="Not specified",
                 uri="Related ID blank relationType blank relatedIdentifierType",
             ),
         ],
         rights=[
-            Rights(description="Right no URI"),
-            Rights(description="Right blank URI"),
-            Rights(uri="Right URI without string"),
+            timdex.Rights(description="Right no URI"),
+            timdex.Rights(description="Right blank URI"),
+            timdex.Rights(uri="Right URI without string"),
         ],
-        subjects=[Subject(value=["Subject One"], kind="Subject scheme not provided")],
+        subjects=[
+            timdex.Subject(value=["Subject One"], kind="Subject scheme not provided")
+        ],
     )
 
 
@@ -394,8 +385,8 @@ def test_get_alternate_titles_success():
         """
     )
     assert Datacite.get_alternate_titles(source_record) == [
-        AlternateTitle(value="An Alternative Title", kind="AlternativeTitle"),
-        AlternateTitle(value="Baseline Data", kind="Subtitle"),
+        timdex.AlternateTitle(value="An Alternative Title", kind="AlternativeTitle"),
+        timdex.AlternateTitle(value="Baseline Data", kind="Subtitle"),
     ]
 
 
@@ -472,25 +463,25 @@ def test_get_contributors_success():
         """
     )
     assert Datacite.get_contributors(source_record) == [
-        Contributor(
+        timdex.Contributor(
             value="Banerji, Rukmini",
             affiliation=["Pratham and ASER Centre"],
             identifier=["https://orcid.org/0000-0000-0000-0000"],
             kind="Creator",
         ),
-        Contributor(
+        timdex.Contributor(
             value="Berry, James",
             affiliation=["University of Delaware"],
             identifier=["0000-0000-0000-0001"],
             kind="Creator",
         ),
-        Contributor(
+        timdex.Contributor(
             value="Shotland, Marc",
             affiliation=["Abdul Latif Jameel Poverty Action Lab"],
             identifier=["0000-0000-0000-0002"],
             kind="Creator",
         ),
-        Contributor(
+        timdex.Contributor(
             value="Banerji, Rukmini",
             affiliation=["Pratham and ASER Centre"],
             identifier=["https://orcid.org/0000-0000-0000-0000"],
@@ -530,12 +521,14 @@ def test_get_dates_success():
         """
     )
     assert Datacite.get_dates(source_record) == [
-        Date(kind="Publication date", value="2017"),
-        Date(kind="Submitted", value="2017-02-27"),
-        Date(kind="Updated", note="This was updated on this date", value="2019-06-24"),
-        Date(
+        timdex.Date(kind="Publication date", value="2017"),
+        timdex.Date(kind="Submitted", value="2017-02-27"),
+        timdex.Date(
+            kind="Updated", note="This was updated on this date", value="2019-06-24"
+        ),
+        timdex.Date(
             kind="Collected",
-            range=DateRange(gte="2007-01-01", lte="2007-02-28"),
+            range=timdex.DateRange(gte="2007-01-01", lte="2007-02-28"),
         ),
     ]
 
@@ -633,7 +626,7 @@ def test_get_funding_information_success():
         """
     )
     assert Datacite.get_funding_information(source_record) == [
-        Funder(
+        timdex.Funder(
             funder_name="3ie, Nike Foundation",
             funder_identifier="0987",
             funder_identifier_type="Crossref FunderID",
@@ -677,9 +670,9 @@ def test_get_identifiers_success():
         """
     )
     assert Datacite.get_identifiers(source_record) == [
-        Identifier(value="10.7910/DVN/19PPE7", kind="DOI"),
-        Identifier(value="https://zenodo.org/record/5524465", kind="url"),
-        Identifier(value="1234567.5524464", kind="IsIdenticalTo"),
+        timdex.Identifier(value="10.7910/DVN/19PPE7", kind="DOI"),
+        timdex.Identifier(value="https://zenodo.org/record/5524465", kind="url"),
+        timdex.Identifier(value="1234567.5524464", kind="IsIdenticalTo"),
     ]
 
 
@@ -722,7 +715,7 @@ def test_get_links_success(datacite_record_all_fields):
     source_record = create_datacite_source_record_stub()
     datacite_transformer = Datacite("jpal", datacite_record_all_fields)
     assert datacite_transformer.get_links(source_record) == [
-        Link(
+        timdex.Link(
             url="https://dataverse.harvard.edu/dataset.xhtml?persistentId=abc123",
             kind="Digital object URL",
             text="Digital object URL",
@@ -741,7 +734,7 @@ def test_get_locations_success():
         """
     )
     assert Datacite.get_locations(source_record) == [
-        Location(value="A point on the globe")
+        timdex.Location(value="A point on the globe")
     ]
 
 
@@ -767,8 +760,8 @@ def test_get_notes_success():
         """
     )
     assert Datacite.get_notes(source_record) == [
-        Note(value=["Survey Data"], kind="Datacite resource type"),
-        Note(value=["Stata, 13"], kind="TechnicalInfo"),
+        timdex.Note(value=["Survey Data"], kind="Datacite resource type"),
+        timdex.Note(value=["Stata, 13"], kind="TechnicalInfo"),
     ]
 
 
@@ -788,7 +781,9 @@ def test_get_publishers_success():
     source_record = create_datacite_source_record_stub(
         "<publisher>Harvard Dataverse</publisher>"
     )
-    assert Datacite.get_publishers(source_record) == [Publisher(name="Harvard Dataverse")]
+    assert Datacite.get_publishers(source_record) == [
+        timdex.Publisher(name="Harvard Dataverse")
+    ]
 
 
 def test_get_publishers_transforms_correctly_if_fields_blank():
@@ -814,10 +809,12 @@ def test_get_related_items_success():
     )
     source_record = create_datacite_source_record_stub(metadata_insert)
     assert Datacite.get_related_items(source_record) == [
-        RelatedItem(relationship="IsCitedBy", uri="https://doi.org/10.1257/app.20150390"),
-        RelatedItem(relationship="IsVersionOf", uri="10.5281/zenodo.5524464"),
-        RelatedItem(relationship="Other", uri="1234567.5524464"),
-        RelatedItem(
+        timdex.RelatedItem(
+            relationship="IsCitedBy", uri="https://doi.org/10.1257/app.20150390"
+        ),
+        timdex.RelatedItem(relationship="IsVersionOf", uri="10.5281/zenodo.5524464"),
+        timdex.RelatedItem(relationship="Other", uri="1234567.5524464"),
+        timdex.RelatedItem(
             relationship="IsPartOf",
             uri="https://zenodo.org/communities/astronomy-general",
         ),
@@ -847,8 +844,10 @@ def test_get_rights_success():
         """
     )
     assert Datacite.get_rights(source_record) == [
-        Rights(description=None, kind=None, uri="info:eu-repo/semantics/openAccess"),
-        Rights(
+        timdex.Rights(
+            description=None, kind=None, uri="info:eu-repo/semantics/openAccess"
+        ),
+        timdex.Rights(
             description="CC0 1.0",
             kind=None,
             uri="http://creativecommons.org/publicdomain/zero/1.0",
@@ -881,11 +880,11 @@ def test_get_subjects_success():
         """
     )
     assert Datacite.get_subjects(source_record) == [
-        Subject(
+        timdex.Subject(
             value=["Social Sciences", "Educational materials"],
             kind="Subject scheme not provided",
         ),
-        Subject(
+        timdex.Subject(
             value=[
                 "Adult education, education inputs, field experiments",
                 "Education",

--- a/tests/sources/xml/test_dspace_mets.py
+++ b/tests/sources/xml/test_dspace_mets.py
@@ -233,6 +233,27 @@ def test_get_alternate_titles_transforms_correctly_if_fields_missing():
     assert DspaceMets.get_alternate_titles(source_record) is None
 
 
+def test_get_alternate_titles_multiple_titles_success():
+
+    source_record = create_dspace_mets_source_record_stub(
+        """
+        <mods:titleInfo>
+         <mods:title>Title 1</mods:title>"
+        </mods:titleInfo>
+        <mods:titleInfo>
+         <mods:title>Title 2</mods:title>
+        </mods:titleInfo>
+        <mods:titleInfo>
+         <mods:title>Title 3</mods:title>
+        </mods:titleInfo>
+        """
+    )
+    assert DspaceMets.get_alternate_titles(source_record) == [
+        timdex.AlternateTitle(value="Title 2"),
+        timdex.AlternateTitle(value="Title 3"),
+    ]
+
+
 def test_get_citation_success():
     xml_string = (
         '<mods:identifier type="citation">Tatsumi, Yuki. "Magneto-thermal '

--- a/tests/sources/xml/test_dspace_mets.py
+++ b/tests/sources/xml/test_dspace_mets.py
@@ -1,86 +1,40 @@
+from bs4 import BeautifulSoup
+
 import transmogrifier.models as timdex
 from transmogrifier.sources.xml.dspace_mets import DspaceMets
 
 
-def test_dspace_mets_transform_with_missing_optional_fields_transforms_correctly():
-    dspace_xml_records = DspaceMets.parse_source_file(
-        "tests/fixtures/dspace/dspace_mets_record_optional_fields_missing.xml"
-    )
-    output_records = DspaceMets("dspace", dspace_xml_records)
-    assert next(output_records) == timdex.TimdexRecord(
-        source="DSpace@MIT",
-        source_link="https://dspace.mit.edu/handle/1721.1/142832",
-        timdex_record_id="dspace:1721.1-142832",
-        title="Title not provided",
-        citation="Title not provided. https://dspace.mit.edu/handle/1721.1/142832",
-        format="electronic resource",
-        content_type=["Not specified"],
-    )
-
-
-def test_dspace_mets_transform_with_blank_optional_fields_transforms_correctly():
-    dspace_xml_records = DspaceMets.parse_source_file(
-        "tests/fixtures/dspace/dspace_mets_record_optional_fields_blank.xml"
-    )
-    output_records = DspaceMets("dspace", dspace_xml_records)
-    assert next(output_records) == timdex.TimdexRecord(
-        source="DSpace@MIT",
-        source_link="https://dspace.mit.edu/handle/1721.1/142832",
-        timdex_record_id="dspace:1721.1-142832",
-        title="Title not provided",
-        citation="Title not provided. https://dspace.mit.edu/handle/1721.1/142832",
-        format="electronic resource",
-        content_type=["Not specified"],
-    )
-
-
-def test_dspace_mets_with_attribute_and_subfield_variations_transforms_correctly():
-    dspace_xml_records = DspaceMets.parse_source_file(
-        "tests/fixtures/dspace/dspace_mets_record_attribute_and_subfield_variations.xml"
-    )
-    output_records = DspaceMets("dspace", dspace_xml_records)
-    assert next(output_records) == timdex.TimdexRecord(
-        source="DSpace@MIT",
-        source_link="https://dspace.mit.edu/handle/1721.1/142832",
-        timdex_record_id="dspace:1721.1-142832",
-        title="Title with Blank Type",
-        citation="Title with Blank Type. 2021-09. Thesis. "
-        "https://dspace.mit.edu/handle/1721.1/142832",
-        alternate_titles=[timdex.AlternateTitle(value="Second Title with Blank Type")],
-        content_type=["Thesis"],
-        contributors=[
-            timdex.Contributor(value="One, Author", kind="Not specified"),
-            timdex.Contributor(value="Two, Author", kind="Not specified"),
-            timdex.Contributor(value="Three, Author", kind="Not specified"),
-        ],
-        dates=[timdex.Date(kind="Publication date", value="2021-09")],
-        file_formats=["application/pdf"],
-        format="electronic resource",
-        identifiers=[
-            timdex.Identifier(kind="Not specified", value="ID-no-type"),
-            timdex.Identifier(kind="Not specified", value="ID-blank-type"),
-            timdex.Identifier(kind="uri", value="https://link-to-item"),
-        ],
-        links=[
-            timdex.Link(
-                kind="Digital object URL",
-                text="Digital object URL",
-                url="https://link-to-item",
-            )
-        ],
-        related_items=[
-            timdex.RelatedItem(
-                description="Related item no type", relationship="Not specified"
-            ),
-            timdex.RelatedItem(
-                description="Related item blank type", relationship="Not specified"
-            ),
-        ],
-        rights=[
-            timdex.Rights(description="Access condition no type"),
-            timdex.Rights(description="Access condition blank type"),
-        ],
-    )
+def create_dspace_mets_source_record_stub(xml_insert: str = "") -> BeautifulSoup:
+    xml_string = f"""
+        <records>
+         <record xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <header>
+            <identifier>abc123</identifier>
+          <header>
+          <metadata>
+           <mets xmlns="http://www.loc.gov/METS/"
+                xmlns:doc="http://www.lyncode.com/xoai"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xsi:schemaLocation="http://www.loc.gov/METS/
+            <dmdSec ID="DMD_1721.1_142832">
+             <mdWrap MDTYPE="MODS">
+              <xmlData xmlns:mods="http://www.loc.gov/mods/v3"
+               xsi:schemaLocation="http://www.loc.gov/mods/v3
+               http://www.loc.gov/standards/mods/v3/mods-3-1.xsd">
+                <mods:mods>
+                {xml_insert}
+                </mods:mods>
+              </xmlData>
+             </mdWrap>
+            </dmdSec>
+           </mets>
+          </metadata>
+         </record>
+        </records>
+        """
+    return BeautifulSoup(xml_string, "xml")
 
 
 def test_dspace_mets_transform_with_all_fields_transforms_correctly():
@@ -171,3 +125,152 @@ def test_dspace_mets_transform_with_all_fields_transforms_correctly():
             "complex magnets are described."
         ],
     )
+
+
+def test_dspace_mets_transform_with_blank_optional_fields_transforms_correctly():
+    dspace_xml_records = DspaceMets.parse_source_file(
+        "tests/fixtures/dspace/dspace_mets_record_optional_fields_blank.xml"
+    )
+    output_records = DspaceMets("dspace", dspace_xml_records)
+    assert next(output_records) == timdex.TimdexRecord(
+        source="DSpace@MIT",
+        source_link="https://dspace.mit.edu/handle/1721.1/142832",
+        timdex_record_id="dspace:1721.1-142832",
+        title="Title not provided",
+        citation="Title not provided. https://dspace.mit.edu/handle/1721.1/142832",
+        format="electronic resource",
+        content_type=["Not specified"],
+    )
+
+
+def test_dspace_mets_transform_with_missing_optional_fields_transforms_correctly():
+    dspace_xml_records = DspaceMets.parse_source_file(
+        "tests/fixtures/dspace/dspace_mets_record_optional_fields_missing.xml"
+    )
+    output_records = DspaceMets("dspace", dspace_xml_records)
+    assert next(output_records) == timdex.TimdexRecord(
+        source="DSpace@MIT",
+        source_link="https://dspace.mit.edu/handle/1721.1/142832",
+        timdex_record_id="dspace:1721.1-142832",
+        title="Title not provided",
+        citation="Title not provided. https://dspace.mit.edu/handle/1721.1/142832",
+        format="electronic resource",
+        content_type=["Not specified"],
+    )
+
+
+def test_dspace_mets_with_attribute_and_subfield_variations_transforms_correctly():
+    dspace_xml_records = DspaceMets.parse_source_file(
+        "tests/fixtures/dspace/dspace_mets_record_attribute_and_subfield_variations.xml"
+    )
+    output_records = DspaceMets("dspace", dspace_xml_records)
+    assert next(output_records) == timdex.TimdexRecord(
+        source="DSpace@MIT",
+        source_link="https://dspace.mit.edu/handle/1721.1/142832",
+        timdex_record_id="dspace:1721.1-142832",
+        title="Title with Blank Type",
+        citation="Title with Blank Type. 2021-09. Thesis. "
+        "https://dspace.mit.edu/handle/1721.1/142832",
+        alternate_titles=[timdex.AlternateTitle(value="Second Title with Blank Type")],
+        content_type=["Thesis"],
+        contributors=[
+            timdex.Contributor(value="One, Author", kind="Not specified"),
+            timdex.Contributor(value="Two, Author", kind="Not specified"),
+            timdex.Contributor(value="Three, Author", kind="Not specified"),
+        ],
+        dates=[timdex.Date(kind="Publication date", value="2021-09")],
+        file_formats=["application/pdf"],
+        format="electronic resource",
+        identifiers=[
+            timdex.Identifier(kind="Not specified", value="ID-no-type"),
+            timdex.Identifier(kind="Not specified", value="ID-blank-type"),
+            timdex.Identifier(kind="uri", value="https://link-to-item"),
+        ],
+        links=[
+            timdex.Link(
+                kind="Digital object URL",
+                text="Digital object URL",
+                url="https://link-to-item",
+            )
+        ],
+        related_items=[
+            timdex.RelatedItem(
+                description="Related item no type", relationship="Not specified"
+            ),
+            timdex.RelatedItem(
+                description="Related item blank type", relationship="Not specified"
+            ),
+        ],
+        rights=[
+            timdex.Rights(description="Access condition no type"),
+            timdex.Rights(description="Access condition blank type"),
+        ],
+    )
+
+
+def test_get_alternate_titles_success():
+    source_record = create_dspace_mets_source_record_stub(
+        """
+        <mods:titleInfo>
+         <mods:title type="alternative">A Slightly Different Title</mods:title>
+        </mods:titleInfo>
+        """
+    )
+    assert DspaceMets.get_alternate_titles(source_record) == [
+        timdex.AlternateTitle(value="A Slightly Different Title", kind="alternative")
+    ]
+
+
+def test_get_alternate_titles_transforms_correctly_if_fields_blank():
+    source_record = create_dspace_mets_source_record_stub(
+        '<titles><title titleType="AlternativeTitle"></title></titles>'
+    )
+    assert DspaceMets.get_alternate_titles(source_record) is None
+
+
+def test_get_alternate_titles_transforms_correctly_if_fields_missing():
+    source_record = create_dspace_mets_source_record_stub()
+    assert DspaceMets.get_alternate_titles(source_record) is None
+
+
+def test_get_citation_success():
+    xml_string = (
+        '<mods:identifier type="citation">Tatsumi, Yuki. "Magneto-thermal '
+        'Transport and Machine Learning-assisted Investigation of Magnetic Materials." '
+        "Massachusetts Institute of Technology © 2022.</mods:identifier>"
+    )
+    source_record = create_dspace_mets_source_record_stub(xml_string)
+    assert DspaceMets.get_citation(source_record) == (
+        'Tatsumi, Yuki. "Magneto-thermal Transport and Machine Learning-assisted '
+        'Investigation of Magnetic Materials." Massachusetts Institute of Technology '
+        "© 2022."
+    )
+
+
+def test_get_citation_transforms_correctly_if_fields_blank():
+    source_record = create_dspace_mets_source_record_stub(
+        '<mods:identifier type="citation"></mods:identifier>'
+    )
+    assert DspaceMets.get_citation(source_record) is None
+
+
+def test_get_citation_transforms_correctly_if_fields_missing():
+    source_record = create_dspace_mets_source_record_stub()
+    assert DspaceMets.get_citation(source_record) is None
+
+
+def test_get_content_type_success():
+    source_record = create_dspace_mets_source_record_stub(
+        "<mods:genre>Thesis</mods:genre>"
+    )
+    assert DspaceMets.get_content_type(source_record) == ["Thesis"]
+
+
+def test_get_content_type_transforms_correctly_if_fields_blank():
+    source_record = create_dspace_mets_source_record_stub("<mods:genre />")
+    assert DspaceMets.get_content_type(source_record) is None
+
+
+def test_get_content_type_transforms_correctly_if_fields_missing():
+    source_record = create_dspace_mets_source_record_stub()
+    assert DspaceMets.get_content_type(source_record) is None

--- a/transmogrifier/sources/xml/dspace_mets.py
+++ b/transmogrifier/sources/xml/dspace_mets.py
@@ -189,9 +189,12 @@ class DspaceMets(XMLTransformer):
             if alternate_title.get("type")
         ]
         # If the record has more than one main title, add extras to alternate_titles
-        for index, title in enumerate(cls.get_main_titles(source_record)):
-            if index > 0:
-                alternate_titles.append(timdex.AlternateTitle(value=title))
+        alternate_titles.extend(
+            [
+                timdex.AlternateTitle(value=title)
+                for title in cls.get_main_titles(source_record)[1:]
+            ]
+        )
         return alternate_titles or None
 
     @classmethod


### PR DESCRIPTION
### Purpose and background context
Refactors the first set of `DspaceMets` fields as separate field methods. The absurd line count is from updating the METS fixtures and updating the imports for `test_datacite.py` to bring it in line with the other unit test modules in the repo. The actual code changes are ~250 lines.

### How can a reviewer manually see the effects of these changes?
Run the following command to see that the `DspaceMets` transform still transforms a source file:

```
pipenv run transform -i tests/fixtures/dspace/dspace_mets_records.xml -o output/dspace-mets-transformed-records.json -s dspace
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-286

### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

