### PR TITLE
Add final set of DspaceMets field methods

### DIFF
--- a/transmogrifier/sources/xml/dspace_mets.py
+++ b/transmogrifier/sources/xml/dspace_mets.py
@@ -155,8 +155,12 @@ class DspaceMets(XMLTransformer):
 
     @classmethod
     def get_dates(cls, source_record: Tag) -> list[timdex.Date] | None:
-        # Only publication date is mapped from DSpace, other relevant date field (dc.
-        # coverage.temporal) is not mapped to the OAI-PMH METS output.
+        """
+        Field method for dates.
+
+        Only publication date is mapped from DSpace, other relevant date field
+        (dc.coverage.temporal) is not mapped to the OAI-PMH METS output.
+        """
         if publication_date := source_record.find("mods:dateIssued", string=True):
             publication_date_value = str(publication_date.string.strip())
             if validate_date(
@@ -169,8 +173,12 @@ class DspaceMets(XMLTransformer):
 
     @classmethod
     def get_file_formats(cls, source_record: Tag) -> list[str] | None:
-        # Only maps formats with attribute use="ORIGINAL" because other formats such as
-        # USE="TEXT" are used internally by DSpace and not made publicly available.
+        """
+        Field method for file_formats.
+
+        Only maps formats with attribute use="ORIGINAL" because other formats such as
+        USE="TEXT" are used internally by DSpace and not made publicly available.
+        """
         file_formats = []
         for file_group in source_record.find_all("fileGrp", USE="ORIGINAL"):
             file = file_group.find("file")
@@ -239,8 +247,12 @@ class DspaceMets(XMLTransformer):
 
     @classmethod
     def get_rights(cls, source_record: Tag) -> list[timdex.Rights] | None:
-        # Note: rights uri field in DSpace (dc.rights.uri) is not mapped to the OAI-PMH
-        # METS output.
+        """
+        Field method for rights.
+
+        Rights uri field in DSpace (dc.rights.uri) is not mapped to the OAI-PMH
+        METS output.
+        """
         return [
             timdex.Rights(description=str(right.string), kind=right.get("type") or None)
             for right in source_record.find_all("mods:accessCondition", string=True)
@@ -248,8 +260,12 @@ class DspaceMets(XMLTransformer):
 
     @classmethod
     def get_subjects(cls, source_record: Tag) -> list[timdex.Subject] | None:
-        # Note: subject fields with schemes in DSpace (dc.subject.<scheme>) are not
-        # mapped to the OAI-PMH METS output.
+        """
+        Field method for subjects.
+
+        Subject fields with schemes in DSpace (dc.subject.<scheme>) are not
+        mapped to the OAI-PMH METS output.
+        """
         if subjects := source_record.find_all("mods:topic", string=True):
             return [
                 timdex.Subject(


### PR DESCRIPTION
### Purpose and background context
Finish refactoring `DspaceMets` transform to use field methods. Just under our suggested limit 😬 

### How can a reviewer manually see the effects of these changes?
Run the following command to see that the `DspaceMets` transform still transforms a source file:

```
pipenv run transform -i tests/fixtures/dspace/dspace_mets_records.xml -o output/dspace-mets-transformed-records.json -s dspace
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-286

### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

