### PR TITLE
Timx 332 dedupe function

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,15 +1,6 @@
 import pytest
 
-from transmogrifier.models import (
-    AlternateTitle,
-    Contributor,
-    Date,
-    DateRange,
-    Identifier,
-    Link,
-    Note,
-    Subject,
-)
+import transmogrifier.models as timdex
 
 
 def test_timdex_record_required_fields_only(timdex_record_required_fields):
@@ -45,14 +36,16 @@ def test_timdex_record_required_fields_only(timdex_record_required_fields):
 
 
 def test_timdex_record_required_subfields_only(timdex_record_required_fields):
-    timdex_record_required_fields.contributors = [Contributor(value="Smith, Jane")]
-    timdex_record_required_fields.identifiers = [Identifier(value="123")]
+    timdex_record_required_fields.contributors = [timdex.Contributor(value="Smith, Jane")]
+    timdex_record_required_fields.identifiers = [timdex.Identifier(value="123")]
     timdex_record_required_fields.links = [
-        Link(url="http://dx.doi.org/10.1007/978-94-017-0726-8")
+        timdex.Link(url="http://dx.doi.org/10.1007/978-94-017-0726-8")
     ]
-    timdex_record_required_fields.notes = [Note(value=["This book is awesome"])]
-    timdex_record_required_fields.alternate_titles = [AlternateTitle(value="Alt Title")]
-    timdex_record_required_fields.subjects = [Subject(value=["Stuff"])]
+    timdex_record_required_fields.notes = [timdex.Note(value=["This book is awesome"])]
+    timdex_record_required_fields.alternate_titles = [
+        timdex.AlternateTitle(value="Alt Title")
+    ]
+    timdex_record_required_fields.subjects = [timdex.Subject(value=["Stuff"])]
     assert timdex_record_required_fields.source == "A Cool Repository"
     assert timdex_record_required_fields.source_link == "https://example.com/123"
     assert timdex_record_required_fields.timdex_record_id == "cool-repo:123"
@@ -337,8 +330,10 @@ def test_timdex_record_date_range_both_gt_and_gte_raises_error(
         match="range may have a 'gt' or 'gte' value, but not both;",
     ):
         timdex_record_required_fields.dates = [
-            Date(
-                range=DateRange(gt="2019-01-01", gte="2019-01-01", lt="2019-06-30"),
+            timdex.Date(
+                range=timdex.DateRange(
+                    gt="2019-01-01", gte="2019-01-01", lt="2019-06-30"
+                ),
             )
         ]
 
@@ -350,8 +345,10 @@ def test_timdex_record_date_range_both_lt_and_lte_raises_error(
         ValueError, match="range may have a 'lt' or 'lte' value, but not both;"
     ):
         timdex_record_required_fields.dates = [
-            Date(
-                range=DateRange(gt="2019-01-01", lt="2019-06-30", lte="2019-06-30"),
+            timdex.Date(
+                range=timdex.DateRange(
+                    gt="2019-01-01", lt="2019-06-30", lte="2019-06-30"
+                ),
             )
         ]
 
@@ -374,3 +371,239 @@ def test_timdex_record_not_a_list_raises_error(timdex_record_required_fields):
         match="'dates' must be <class 'list'>",
     ):
         timdex_record_required_fields.dates = "test"
+
+
+def test_timdex_record_dedupe_alternate_titles(timdex_record_required_fields):
+    timdex_record_required_fields.alternate_titles = [
+        timdex.AlternateTitle(value="My Octopus Teacher"),
+        timdex.AlternateTitle(value="My Octopus Teacher"),
+    ]
+    assert timdex_record_required_fields.alternate_titles == [
+        timdex.AlternateTitle(value="My Octopus Teacher")
+    ]
+
+
+def test_timdex_record_dedupe_call_numbers(timdex_record_required_fields):
+    timdex_record_required_fields.call_numbers = ["a", "a"]
+    assert timdex_record_required_fields.call_numbers == ["a"]
+
+
+def test_timdex_record_dedupe_content_type(timdex_record_required_fields):
+    timdex_record_required_fields.content_type = ["thesis", "thesis"]
+    assert timdex_record_required_fields.content_type == ["thesis"]
+
+
+def test_timdex_record_dedupe_contents(timdex_record_required_fields):
+    timdex_record_required_fields.contents = ["Chapter 1", "Chapter 1"]
+    assert timdex_record_required_fields.contents == ["Chapter 1"]
+
+
+def test_timdex_record_dedupe_contributors(timdex_record_required_fields):
+    timdex_record_required_fields.contributors = [
+        timdex.Contributor(
+            value="Joe Hisaishi",
+            affiliation=["Kunitachi College of Music"],
+            kind="Composer",
+        ),
+        timdex.Contributor(
+            value="Joe Hisaishi",
+            affiliation=["Kunitachi College of Music"],
+            kind="Composer",
+        ),
+    ]
+    assert timdex_record_required_fields.contributors == [
+        timdex.Contributor(
+            value="Joe Hisaishi",
+            affiliation=["Kunitachi College of Music"],
+            kind="Composer",
+        )
+    ]
+
+
+def test_timdex_record_dedupe_dates(timdex_record_required_fields):
+    timdex_record_required_fields.dates = [
+        timdex.Date(value="2022-01-01", kind="Publication date"),
+        timdex.Date(value="2022-01-01", kind="Publication date"),
+        timdex.Date(
+            range=timdex.DateRange(gt="2019-01-01", lt="2019-06-30"),
+        ),
+        timdex.Date(
+            range=timdex.DateRange(gt="2019-01-01", lt="2019-06-30"),
+        ),
+    ]
+    assert timdex_record_required_fields.dates == [
+        timdex.Date(value="2022-01-01", kind="Publication date"),
+        timdex.Date(
+            range=timdex.DateRange(gt="2019-01-01", lt="2019-06-30"),
+        ),
+    ]
+
+
+def test_timdex_record_dedupe_file_formats(timdex_record_required_fields):
+    timdex_record_required_fields.file_formats = [
+        "application/pdf",
+        "application/pdf",
+    ]
+    assert timdex_record_required_fields.file_formats == ["application/pdf"]
+
+
+def test_timdex_record_dedupe_funding_information(timdex_record_required_fields):
+    timdex_record_required_fields.funding_information = [
+        timdex.Funder(funder_name="NPR Foundation"),
+        timdex.Funder(funder_name="NPR Foundation"),
+    ]
+    assert timdex_record_required_fields.funding_information == [
+        timdex.Funder(funder_name="NPR Foundation")
+    ]
+
+
+def test_timdex_record_dedupe_holdings(timdex_record_required_fields):
+    timdex_record_required_fields.holdings = [
+        timdex.Holding(
+            call_number="PL2687.L8.A28 1994",
+            collection="Stacks",
+            format="Print volume",
+            location="Hayden Library",
+        ),
+        timdex.Holding(
+            call_number="PL2687.L8.A28 1994",
+            collection="Stacks",
+            format="Print volume",
+            location="Hayden Library",
+        ),
+    ]
+    assert timdex_record_required_fields.holdings == [
+        timdex.Holding(
+            call_number="PL2687.L8.A28 1994",
+            collection="Stacks",
+            format="Print volume",
+            location="Hayden Library",
+        )
+    ]
+
+
+def test_timdex_record_dedupe_identifiers(timdex_record_required_fields):
+    timdex_record_required_fields.identifiers = [
+        timdex.Identifier(value="9781250185969. hardcover", kind="ISBN"),
+        timdex.Identifier(value="9781250185969. hardcover", kind="ISBN"),
+    ]
+    assert timdex_record_required_fields.identifiers == [
+        timdex.Identifier(value="9781250185969. hardcover", kind="ISBN")
+    ]
+
+
+def test_timdex_record_dedupe_languages(timdex_record_required_fields):
+    timdex_record_required_fields.languages = ["Spanish", "Spanish"]
+    assert timdex_record_required_fields.languages == ["Spanish"]
+
+
+def test_timdex_record_dedupe_links(timdex_record_required_fields):
+    timdex_record_required_fields.links = [
+        timdex.Link(
+            url="https://geodata.libraries.mit.edu/record/gismit"
+            ":GISPORTAL_GISOWNER01_BOSTONWATER95",
+            kind="Website",
+            text="Website",
+        ),
+        timdex.Link(
+            url="https://geodata.libraries.mit.edu/record/gismit"
+            ":GISPORTAL_GISOWNER01_BOSTONWATER95",
+            kind="Website",
+            text="Website",
+        ),
+    ]
+    assert timdex_record_required_fields.links == [
+        timdex.Link(
+            url="https://geodata.libraries.mit.edu/record/gismit"
+            ":GISPORTAL_GISOWNER01_BOSTONWATER95",
+            kind="Website",
+            text="Website",
+        )
+    ]
+
+
+def test_timdex_record_dedupe_locations(timdex_record_required_fields):
+    timdex_record_required_fields.locations = [
+        timdex.Location(value="One Place", kind="Place of Publication"),
+        timdex.Location(value="One Place", kind="Place of Publication"),
+    ]
+    assert timdex_record_required_fields.locations == [
+        timdex.Location(value="One Place", kind="Place of Publication")
+    ]
+
+
+def test_timdex_record_dedupe_notes(timdex_record_required_fields):
+    timdex_record_required_fields.notes = [
+        timdex.Note(value=["Survey Data"], kind="Datacite resource type"),
+        timdex.Note(value=["Survey Data"], kind="Datacite resource type"),
+    ]
+    assert timdex_record_required_fields.notes == [
+        timdex.Note(value=["Survey Data"], kind="Datacite resource type"),
+    ]
+
+
+def test_timdex_record_dedupe_publication_frequency(timdex_record_required_fields):
+    timdex_record_required_fields.publication_frequency = [
+        "Three times a year",
+        "Three times a year",
+    ]
+    assert timdex_record_required_fields.publication_frequency == ["Three times a year"]
+
+
+def test_timdex_record_dedupe_publishers(timdex_record_required_fields):
+    timdex_record_required_fields.publishers = [
+        timdex.Publisher(name="Harvard Dataverse"),
+        timdex.Publisher(name="Harvard Dataverse"),
+    ]
+    assert timdex_record_required_fields.publishers == [
+        timdex.Publisher(name="Harvard Dataverse")
+    ]
+
+
+def test_timdex_record_dedupe_related_items(timdex_record_required_fields):
+    timdex_record_required_fields.related_items = [
+        timdex.RelatedItem(description="Nature Communications", relationship="host"),
+        timdex.RelatedItem(description="Nature Communications", relationship="host"),
+    ]
+    assert timdex_record_required_fields.related_items == [
+        timdex.RelatedItem(description="Nature Communications", relationship="host")
+    ]
+
+
+def test_timdex_record_dedupe_rights(timdex_record_required_fields):
+    timdex_record_required_fields.rights = [
+        timdex.Rights(description="MIT authentication required", kind="Access to files"),
+        timdex.Rights(description="MIT authentication required", kind="Access to files"),
+    ]
+    assert timdex_record_required_fields.rights == [
+        timdex.Rights(description="MIT authentication required", kind="Access to files")
+    ]
+
+
+def test_timdex_record_dedupe_subjects(timdex_record_required_fields):
+    timdex_record_required_fields.subjects = [
+        timdex.Subject(
+            value=["Social Sciences", "Educational materials"],
+            kind="Subject scheme not provided",
+        ),
+        timdex.Subject(
+            value=["Social Sciences", "Educational materials"],
+            kind="Subject scheme not provided",
+        ),
+    ]
+    assert timdex_record_required_fields.subjects == [
+        timdex.Subject(
+            value=["Social Sciences", "Educational materials"],
+            kind="Subject scheme not provided",
+        )
+    ]
+
+
+def test_timdex_record_dedupe_summary(timdex_record_required_fields):
+    timdex_record_required_fields.summary = [
+        "Mitochondria is the powerhouse of the cell.",
+        "Mitochondria is the powerhouse of the cell.",
+    ]
+    assert timdex_record_required_fields.summary == [
+        "Mitochondria is the powerhouse of the cell."
+    ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -373,6 +373,30 @@ def test_timdex_record_not_a_list_raises_error(timdex_record_required_fields):
         timdex_record_required_fields.dates = "test"
 
 
+def test_timdex_object_hash_diff_if_diff_class():
+    """
+    Asserts that TIMDEX objects of different class types
+    with similar attributes and attribute values will
+    be assigned different hashes and declared not equal.
+    """
+    identifier = timdex.Identifier(value="x", kind="y")
+    alternate_title = timdex.AlternateTitle(value="x", kind="y")
+    assert identifier != alternate_title
+    assert identifier.__hash__() != alternate_title.__hash__()
+
+
+def test_timdex_object_hash_same_if_same_class():
+    """
+    Asserts that TIMDEX objects of different class types
+    with similar attributes and attribute values will
+    be assigned the same hash and declared equal.
+    """
+    identifier_0 = timdex.Identifier(value="x", kind="y")
+    identifier_1 = timdex.Identifier(value="x", kind="y")
+    assert identifier_0 == identifier_1
+    assert identifier_0.__hash__() == identifier_1.__hash__()
+
+
 def test_timdex_record_dedupe_alternate_titles(timdex_record_required_fields):
     timdex_record_required_fields.alternate_titles = [
         timdex.AlternateTitle(value="My Octopus Teacher"),
@@ -607,3 +631,22 @@ def test_timdex_record_dedupe_summary(timdex_record_required_fields):
     assert timdex_record_required_fields.summary == [
         "Mitochondria is the powerhouse of the cell."
     ]
+
+
+def test_timdex_dedupes_correctly_if_diff_class():
+    items = [
+        timdex.Identifier(value="x", kind="y"),
+        timdex.AlternateTitle(value="x", kind="y"),
+    ]
+    assert timdex.dedupe(items) == [
+        timdex.Identifier(value="x", kind="y"),
+        timdex.AlternateTitle(value="x", kind="y"),
+    ]
+
+
+def test_timdex_dedupes_correctly_if_same_class():
+    items = [
+        timdex.Identifier(value="x", kind="y"),
+        timdex.Identifier(value="x", kind="y"),
+    ]
+    assert timdex.dedupe(items) == [timdex.Identifier(value="x", kind="y")]

--- a/transmogrifier/models.py
+++ b/transmogrifier/models.py
@@ -35,12 +35,6 @@ def list_of(item_type: Any) -> Callable:  # noqa: ANN401
     )
 
 
-def dedupe(item_list: list | Any) -> list | None:  # noqa: ANN401
-    if not isinstance(item_list, list):
-        return item_list
-    return list(dict.fromkeys(item_list))
-
-
 def not_empty(
     _instance: "TimdexRecord", attribute: "attrs.Attribute", value: "list"
 ) -> None:
@@ -49,17 +43,34 @@ def not_empty(
         raise ValueError(message)
 
 
-@define
-class ListField:
-    def __hash__(self) -> int:
-        """Hash method to create unique identifier for Location objects."""
-        values = tuple(
-            [
-                tuple(attrib) if isinstance(attrib, list) else attrib
-                for attrib in attrs.astuple(self)
-            ]
-        )
-        return hash(values)
+def timdex_object_hash(timdex_object: Any) -> int:  # noqa: ANN401
+    """Hash method for TIMDEX objects.
+
+    This method is set as the hash method for TIMDEX objects.
+    The method generates a unique hash using a tuple
+    comprised of the class name and attribute values.
+    By making TIMDEX objects hashable, dedupe methods
+    can be applied to a list of TIMDEX objects.
+    """
+    values = tuple(type(timdex_object).__name__)
+    values += tuple(
+        [
+            tuple(attrib) if isinstance(attrib, list) else attrib
+            for attrib in attrs.astuple(timdex_object)
+        ]
+    )
+    return hash(values)
+
+
+def dedupe(item_list: list | Any) -> list | None:  # noqa: ANN401
+    """Deduplication method for list of items.
+
+    This method is used as a converter function for list fields
+    in the TimdexRecord model.
+    """
+    if not isinstance(item_list, list):
+        return item_list
+    return list(dict.fromkeys(item_list))
 
 
 @define
@@ -67,7 +78,7 @@ class AlternateTitle:
     value: str = field(validator=instance_of(str))  # Required subfield
     kind: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -80,7 +91,7 @@ class Contributor:
         default=None, validator=optional(instance_of(bool))
     )
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -101,7 +112,7 @@ class Date:
     )
     value: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -116,7 +127,7 @@ class Funder:
     award_number: str | None = field(default=None, validator=optional(instance_of(str)))
     award_uri: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -127,7 +138,7 @@ class Holding:
     location: str | None = field(default=None, validator=optional(instance_of(str)))
     note: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -135,7 +146,7 @@ class Identifier:
     value: str = field(validator=instance_of(str))  # Required subfield
     kind: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -145,7 +156,7 @@ class Link:
     restrictions: str | None = field(default=None, validator=optional(instance_of(str)))
     text: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -154,7 +165,7 @@ class Location:
     kind: str | None = field(default=None, validator=optional(instance_of(str)))
     geoshape: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -162,7 +173,7 @@ class Note:
     value: list[str] = field(validator=list_of(str))  # Required subfield
     kind: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -171,7 +182,7 @@ class Publisher:
     date: str | None = field(default=None, validator=optional(instance_of(str)))
     location: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -181,7 +192,7 @@ class RelatedItem:
     relationship: str | None = field(default=None, validator=optional(instance_of(str)))
     uri: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -190,7 +201,7 @@ class Rights:
     kind: str | None = field(default=None, validator=optional(instance_of(str)))
     uri: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define
@@ -198,7 +209,7 @@ class Subject:
     value: list[str] = field(validator=list_of(str))  # Required subfield
     kind: str | None = field(default=None, validator=optional(instance_of(str)))
 
-    __hash__ = ListField.__hash__
+    __hash__ = timdex_object_hash
 
 
 @define

--- a/transmogrifier/models.py
+++ b/transmogrifier/models.py
@@ -52,7 +52,7 @@ def timdex_object_hash(timdex_object: Any) -> int:  # noqa: ANN401
     By making TIMDEX objects hashable, dedupe methods
     can be applied to a list of TIMDEX objects.
     """
-    values = tuple(type(timdex_object).__name__)
+    values = (timdex_object.__class__.__name__,)
     values += tuple(
         [
             tuple(attrib) if isinstance(attrib, list) else attrib


### PR DESCRIPTION
### Purpose and background context

Add a global dedupe method using `attrs` converters to remove duplicated data in `TimdexRecord` fields that comprise of item lists. The following approach was taken:

* Define an `attrs` converter method to dedupe list of items
   * [Converter](https://www.attrs.org/en/stable/init.html#converters) methods can be used to normalize values as they are assigned to an `attrs` class attribute.
   * A [`dedupe` method](https://github.com/MITLibraries/transmogrifier/pull/206/files#diff-62380015f300f79c3d62063c1dffd2c085e0ea5a1cfbf24946e5bb31c36d587cR38-R41) is defined. The method accepts an `item_list` and uses `list(dict.fromkeys(item_list))` to remove duplicates **while retaining the order of items** as they were passed into the list. 
* [Create a `ListField` abstract class with a `__hash__` method](https://github.com/MITLibraries/transmogrifier/pull/206/files#diff-62380015f300f79c3d62063c1dffd2c085e0ea5a1cfbf24946e5bb31c36d587cR52-R62)
   * While the `ListField` was implemented [as we discussed](https://docs.google.com/document/d/1JuKJRmmNK1tdrHYDzwEZf5ZTaChXnLwvJYi9G2nOfmo/edit?usp=sharing), the syntax to have the custom classes inherit the hash method was different than expected. As the [Python 3 docs](https://docs.python.org/3/reference/datamodel.html#object.__hash__) explains:
      > If a class that overrides [__eq__()](https://docs.python.org/3/reference/datamodel.html#object.__eq__) needs to retain the implementation of [__hash__()](https://docs.python.org/3/reference/datamodel.html#object.__hash__) from a parent class, the interpreter must be told this explicitly by setting __hash__ = <ParentClass>.__hash__
      This condition applies as `attrs` overrides / implements `__eq__` methods by default, hence the [hash methods are set for the TIMDEX classes as instructed](https://github.com/MITLibraries/transmogrifier/pull/206/files#diff-62380015f300f79c3d62063c1dffd2c085e0ea5a1cfbf24946e5bb31c36d587cR70).
   * [Why is there a list comprehension in `ListField.__hash__`?](https://github.com/MITLibraries/transmogrifier/pull/206/files#diff-62380015f300f79c3d62063c1dffd2c085e0ea5a1cfbf24946e5bb31c36d587cR56-R61) This is required by the custom classes whose attributes _also_ comprise of list fields (i.e., [Contributor](https://github.com/MITLibraries/transmogrifier/pull/206/files#diff-62380015f300f79c3d62063c1dffd2c085e0ea5a1cfbf24946e5bb31c36d587cR74-R81), [Note](https://github.com/MITLibraries/transmogrifier/pull/206/files#diff-62380015f300f79c3d62063c1dffd2c085e0ea5a1cfbf24946e5bb31c36d587cR161-R163), and [Subject](https://github.com/MITLibraries/transmogrifier/pull/206/files#diff-62380015f300f79c3d62063c1dffd2c085e0ea5a1cfbf24946e5bb31c36d587cR197-R199)).

### How can a reviewer manually see the effects of these changes?
1. Review new tests added in commit: [add dedupe tests for dates and locations](https://github.com/MITLibraries/transmogrifier/pull/206/commits/672dc05982ba7d95cfd32541e5cc00b6195a4d39)

2. Review screenshots showing Docker runs using pulled Docker image from **Dev** (representing latest code in this branch) and Docker image from **Prod** (representing current state). Instructions are provided in the attached Markdown file: [simple_ab_testing.md](https://github.com/user-attachments/files/16625990/simple_ab_testing.md).

<img width="1722" alt="image" src="https://github.com/user-attachments/assets/d7518054-c824-4a5a-9153-347ef9c78df0">


**Note:** All three of us (@ghukill , @ehanson8 , myself) tried this out on our local machines and got similar results! More formal A/B testing will be explored as a separate effort, but all three of us agreed this method is sufficient for purposes of this PR. 

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/TIMX-332

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [x] All related Jira tickets are linked in commit message(s)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

