### PR TITLE
TIMX 403 - Add "run_id" CLI argument and Transformer attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Options:
   -s, --source [alma|aspace|dspace|jpal|libguides|gismit|gisogm|researchdatabases|whoas|zenodo]
                                   Source records were harvested from, must
                                   choose from list of options  [required]
+  -r, --run-id TEXT               Identifier for Transmogrifier run.  This can
+                                  be used to group transformed records
+                                  produced by Transmogrifier, even if they
+                                  span multiple CLI invocations.  If a value
+                                  is not provided a UUID will be minted and
+                                  used.
   -v, --verbose                   Pass to log at debug level instead of info
   --help                          Show this message and exit.
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 import transmogrifier.models as timdex
 from transmogrifier.config import SOURCES, load_external_config
 from transmogrifier.sources.jsontransformer import JSONTransformer
+from transmogrifier.sources.transformer import Transformer
 from transmogrifier.sources.xml.datacite import Datacite
 from transmogrifier.sources.xmltransformer import XMLTransformer
 
@@ -41,6 +42,34 @@ def _bad_config():
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+# transformers ##########################
+
+
+@pytest.fixture
+def generic_transformer():
+
+    class GenericTransformer(Transformer):
+        def parse_source_file(self):
+            pass
+
+        def record_is_deleted(self):
+            pass
+
+        def get_main_titles(self):
+            pass
+
+        def get_source_link(self):
+            pass
+
+        def get_source_record_id(self):
+            pass
+
+        def get_timdex_record_id(self):
+            pass
+
+    return GenericTransformer
 
 
 # aardvark ##########################

--- a/tests/sources/test_transformer.py
+++ b/tests/sources/test_transformer.py
@@ -1,5 +1,7 @@
 # ruff: noqa: PLR2004
 
+import uuid
+
 import pytest
 
 import transmogrifier.models as timdex
@@ -75,3 +77,15 @@ def test_create_locations_from_spatial_subjects_success(timdex_record_required_f
         timdex.Location(value="City 1", kind="Place Name"),
         timdex.Location(value="City 2", kind="Place Name"),
     ]
+
+
+def test_transformer_run_id_explicitly_passed(generic_transformer):
+    run_id = "abc123"
+    transformer = generic_transformer("alma", [], run_id=run_id)
+    assert transformer.run_id == run_id
+
+
+def test_transformer_run_id_none_passed_generates_uuid(generic_transformer):
+    transformer = generic_transformer("alma", [], run_id=None)
+    assert transformer.run_id is not None
+    assert uuid.UUID(transformer.run_id)

--- a/transmogrifier/cli.py
+++ b/transmogrifier/cli.py
@@ -31,10 +31,22 @@ logger = logging.getLogger(__name__)
     help="Source records were harvested from, must choose from list of options",
 )
 @click.option(
+    "-r",
+    "--run-id",
+    required=False,
+    help="Identifier for Transmogrifier run.  This can be used to group transformed "
+    "records produced by Transmogrifier, even if they span multiple CLI invocations.  "
+    "If a value is not provided a UUID will be minted and used.",
+)
+@click.option(
     "-v", "--verbose", is_flag=True, help="Pass to log at debug level instead of info"
 )
 def main(
-    source: str, input_file: str, output_file: str, verbose: bool  # noqa: FBT001
+    source: str,
+    input_file: str,
+    output_file: str,
+    run_id: str,
+    verbose: bool,  # noqa: FBT001
 ) -> None:
     start_time = perf_counter()
     root_logger = logging.getLogger()
@@ -42,7 +54,7 @@ def main(
     logger.info(configure_sentry())
     logger.info("Running transform for source %s", source)
 
-    transformer = Transformer.load(source, input_file)
+    transformer = Transformer.load(source, input_file, run_id=run_id)
     transformer.transform_and_write_output_files(output_file)
     logger.info(
         (


### PR DESCRIPTION
### Purpose and background context

As we move into Transmogrifier writing to a parquet dataset, one important bit of information it will need is the concept of a "run id".  This correlates directly to an "Execution UUID" that every StepFunction invocation produces.  This identifier is then used when writing the records to the parquet dataset, allowing for quick and easy access to records associated with that identifier.

There is a small many-to-one relationship that makes naming a bit awkward: each StepFunction invocation may run Transmogrifier multiple times (e.g. multiple input files).  Each time it invokes Transmogrifier, the same `run_id` would be passed.  This effectively groups the outputs of all Transmogrifier invocations under the same `run_id` partition in the parquet dataset.  The language of this new `run_id` in Transmogrifier is intentionally somewhat high level, indicating it's just an identifier to associate with that invocation of the application.

How this addresses that need:
* Adds new CLI argument `-r / --run-id`
* Transformer gets new attribute `run_id`
* Transformer mints a UUID of a run id is not passed, making the change backwards compatible and inconsequential if a run id is not passed

Side effects of this change:
* Going forward, invocations of Transmogrifier can use the `run_id` as part of the parquet record writing.  Until then, it has no effect.

### How can a reviewer manually see the effects of these changes?

Until the `run_id` is utilized during writing, it has no effect on the output of records at this time.  See the new unit tests for some examples of when and how it's passed.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO (not yet)

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-403

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

