### PR TITLE
TIMX 501 - update aspace oai identifier parsing

### DIFF
--- a/tests/fixtures/ead/ead_record_all_fields.xml
+++ b/tests/fixtures/ead/ead_record_all_fields.xml
@@ -2,7 +2,7 @@
 <records>
     <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <header>
-            <identifier>oai:mit//repositories/2/resources/1</identifier>
+            <identifier>oai:mit/repositories/2/resources/1</identifier>
             <datestamp>2021-11-06T14:35:55Z</datestamp>
         </header>
         <metadata>

--- a/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
+++ b/tests/fixtures/ead/ead_record_attribute_and_subfield_variations.xml
@@ -2,7 +2,7 @@
 <records>
     <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <header>
-            <identifier>oai:mit//repositories/2/resources/6</identifier>
+            <identifier>oai:mit/repositories/2/resources/6</identifier>
             <datestamp>2021-11-06T14:35:55Z</datestamp>
         </header>
         <metadata>

--- a/tests/fixtures/ead/ead_record_blank_optional_fields.xml
+++ b/tests/fixtures/ead/ead_record_blank_optional_fields.xml
@@ -2,7 +2,7 @@
 <records>
     <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <header>
-            <identifier>oai:mit//repositories/2/resources/2</identifier>
+            <identifier>oai:mit/repositories/2/resources/2</identifier>
             <datestamp>2021-11-06T14:35:55Z</datestamp>
         </header>
         <metadata>

--- a/tests/fixtures/ead/ead_record_missing_archdesc.xml
+++ b/tests/fixtures/ead/ead_record_missing_archdesc.xml
@@ -2,7 +2,7 @@
 <records>
     <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <header>
-            <identifier>oai:mit//repositories/2/resources/4</identifier>
+            <identifier>oai:mit/repositories/2/resources/4</identifier>
             <datestamp>2021-11-06T14:35:55Z</datestamp>
         </header>
         <metadata></metadata>

--- a/tests/fixtures/ead/ead_record_missing_archdesc_did.xml
+++ b/tests/fixtures/ead/ead_record_missing_archdesc_did.xml
@@ -2,7 +2,7 @@
 <records>
     <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <header>
-            <identifier>oai:mit//repositories/2/resources/3</identifier>
+            <identifier>oai:mit/repositories/2/resources/3</identifier>
             <datestamp>2021-11-06T14:35:55Z</datestamp>
         </header>
         <metadata>

--- a/tests/fixtures/ead/ead_record_missing_optional_fields.xml
+++ b/tests/fixtures/ead/ead_record_missing_optional_fields.xml
@@ -2,7 +2,7 @@
 <records>
     <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <header>
-            <identifier>oai:mit//repositories/2/resources/5</identifier>
+            <identifier>oai:mit/repositories/2/resources/5</identifier>
             <datestamp>2021-11-06T14:35:55Z</datestamp>
         </header>
         <metadata>

--- a/tests/sources/xml/test_ead.py
+++ b/tests/sources/xml/test_ead.py
@@ -880,7 +880,7 @@ def test_get_dates_success():
     source_record = create_ead_source_record_stub(
         header_insert=(
             """
-            <identifier>oai:mit//repositories/2/resources/1</identifier>
+            <identifier>oai:mit/repositories/2/resources/1</identifier>
             """
         ),
         metadata_insert=(
@@ -907,7 +907,7 @@ def test_get_dates_transforms_correctly_if_fields_blank():
     source_record = create_ead_source_record_stub(
         header_insert=(
             """
-            <identifier>oai:mit//repositories/2/resources/1</identifier>
+            <identifier>oai:mit/repositories/2/resources/1</identifier>
             """
         ),
         metadata_insert=(
@@ -924,7 +924,7 @@ def test_get_dates_transforms_correctly_if_fields_missing():
     source_record = create_ead_source_record_stub(
         header_insert=(
             """
-            <identifier>oai:mit//repositories/2/resources/1</identifier>
+            <identifier>oai:mit/repositories/2/resources/1</identifier>
             """
         ),
         parent_element="did",
@@ -936,7 +936,7 @@ def test_get_dates_transforms_correctly_if_date_invalid():
     source_record = create_ead_source_record_stub(
         header_insert=(
             """
-            <identifier>oai:mit//repositories/2/resources/1</identifier>
+            <identifier>oai:mit/repositories/2/resources/1</identifier>
             """
         ),
         metadata_insert=(
@@ -955,7 +955,7 @@ def test_get_dates_transforms_correctly_if_normal_attribute_missing():
     source_record = create_ead_source_record_stub(
         header_insert=(
             """
-            <identifier>oai:mit//repositories/2/resources/1</identifier>
+            <identifier>oai:mit/repositories/2/resources/1</identifier>
             """
         ),
         metadata_insert=(

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -107,10 +107,10 @@ class Transformer(ABC):
                 self.skipped_record_count += 1
                 action = "skip"
 
-            except Exception as exception:  # noqa: BLE001
+            except Exception as exception:
                 self.error_record_count += 1
                 message = f"Unhandled exception during record transformation: {exception}"
-                logger.warning(message)
+                logger.exception(message)
                 action = "error"
 
             return DatasetRecord(

--- a/transmogrifier/sources/xml/ead.py
+++ b/transmogrifier/sources/xml/ead.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import Generator
 
 from bs4 import NavigableString, Tag  # type: ignore[import-untyped]
@@ -549,7 +550,14 @@ class Ead(XMLTransformer):
         Args:
             source_record: A BeautifulSoup Tag representing a single EAD XML record.
         """
-        return source_record.header.identifier.string.split("//")[1]
+        matches = re.match(r"oai:mit/+(.*)", source_record.header.identifier.string)
+        if not matches:
+            message = (
+                "Could not parse TIMDEX identifier from OAI identifier: "
+                f"'{source_record.header.identifier.string}'"
+            )
+            raise ValueError(message)
+        return matches.groups()[0]
 
     @classmethod
     def parse_mixed_value(


### PR DESCRIPTION
### Purpose and background context

Updates the EAD transformer to handle OAI identifiers with one or two forward slashes in the identifier, e.g.:

- `oai:mit//repository:42`
- `oai:mit/repository:42`

Where the extracted TIMDEX identifier should be `repository:42` for both.

As noted in [TIMX-501](https://mitlibraries.atlassian.net/browse/TIMX-501), this change in the OAI output was from an ASpace 4.x upgrade, is approved by ASpace stakeholders, and will remain the output going forward.  But FWIW, this regex change will handle _either_ situation.

### How can a reviewer manually see the effects of these changes?

Not much to see!  [This line from an EAD test](https://github.com/MITLibraries/transmogrifier/blob/TIMX-501-update-aspace-oai-identifier-parsing/tests/sources/xml/test_ead.py#L86) confirms that, even with the new OAI identifier in the stubbed record, we get the same TIMDEX identifier.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
Importantly, NO: the final `timdex_record_id` will be unchanged despite the source EAD changing its format slightly

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-501

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes



[TIMX-501]: https://mitlibraries.atlassian.net/browse/TIMX-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ