### PR TITLE
TIMX 501 - Handle additional ASpace OAI identifier pattern

### DIFF
--- a/transmogrifier/sources/xml/ead.py
+++ b/transmogrifier/sources/xml/ead.py
@@ -550,7 +550,10 @@ class Ead(XMLTransformer):
         Args:
             source_record: A BeautifulSoup Tag representing a single EAD XML record.
         """
-        matches = re.match(r"oai:mit/+(.*)", source_record.header.identifier.string)
+        matches = re.match(
+            r"oai:mit[/:]+(.*)",
+            source_record.header.identifier.string,
+        )
         if not matches:
             message = (
                 "Could not parse TIMDEX identifier from OAI identifier: "


### PR DESCRIPTION
### Purpose and background context

This PR supports an additional variation on the ASpace OAI identifier we might say.

It was believed that we would only see `oai:mit/...` (single slash) or `oai:mit//...` (double slash), but it appears we may also see `oai:mit:/` (colon + slash).  

This updated regex handles all three cases, and a dedicated unit test is added.

**NOTE**: it is known that [one test is failing in CI](https://github.com/MITLibraries/transmogrifier/actions/runs/15451334108/job/43493916766?pr=253).  It is a test that gets at something finicky around memory management with BS4 + parquet writing.  I would propose to address that failing test seperate of this PR.   Local testing, builds, and actual running in Dev/Stage/Prod has been unaffected.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-501

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes

