### PR TITLE
USE 470 - libguides keywords

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -15,7 +15,4 @@ YES | NO
 - Include links to Jira Software and/or Jira Service Management tickets here.
 
 ### Code review
-* Code review best practices are documented
-[here](https://mitlibraries.github.io/guides/collaboration/code_review.html)
-and you are encouraged to have a constructive dialogue with your reviewers
-about their preferences and expectations.
+* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import boto3
 import pytest
 from click.testing import CliRunner
@@ -295,11 +297,14 @@ def empty_source_input_file():
 
 @pytest.fixture
 def source_transformer(monkeypatch, run_id, source_input_file):
-    return Transformer.load(
-        "cool-repo",
-        source_input_file,
-        run_id=run_id,
-    )
+    mocked_datetime = mock.MagicMock()
+    mocked_datetime.now.return_value.isoformat.return_value = "2024-06-03T12:34:56+00:00"
+    with mock.patch("transmogrifier.sources.transformer.datetime", mocked_datetime):
+        return Transformer.load(
+            "cool-repo",
+            source_input_file,
+            run_id=run_id,
+        )
 
 
 @pytest.fixture

--- a/tests/sources/json/test_libguides.py
+++ b/tests/sources/json/test_libguides.py
@@ -261,6 +261,28 @@ def test_libguides_record_get_fulltext_success(libguides_transformer):
     assert "You should not find me either." not in fulltext
 
 
+def test_libguides_record_get_fulltext_includes_keywords_metadata(
+    libguides_transformer,
+):
+    html_content = """
+    <html>
+        <head>
+            <meta name="keywords" content="alpha, beta"/>
+            <meta name="keywords" content="   "/>
+        </head>
+        <body>
+            <div class="s-lib-main"><p>Content</p></div>
+        </body>
+    </html>
+    """
+    source_record = create_libguides_source_record_stub()
+    source_record["html_base64"] = base64.b64encode(html_content.encode()).decode()
+
+    fulltext = libguides_transformer.get_fulltext(source_record)
+
+    assert set(fulltext.splitlines()) == {"Content", "alpha, beta"}
+
+
 def test_libguides_record_get_summary_success(libguides_transformer):
     source_record = create_libguides_source_record_stub()
     summary = libguides_transformer.get_summary(source_record)

--- a/tests/sources/test_transformer.py
+++ b/tests/sources/test_transformer.py
@@ -141,13 +141,16 @@ def test_create_locations_from_spatial_subjects_success(timdex_record_required_f
 def test_transformer_get_run_data_from_source_file_and_run_id(
     source_transformer, source_input_file, run_id
 ):
-    assert source_transformer.get_run_data(source_input_file, run_id) == {
-        "source": "libguides",
-        "run_date": "2024-06-03",
-        "run_type": "full",
-        "run_id": run_id,
-        "run_timestamp": "2024-06-03T00:00:00",
-    }
+    mocked_datetime = mock.MagicMock()
+    mocked_datetime.now.return_value.isoformat.return_value = "2024-06-03T12:34:56+00:00"
+    with mock.patch("transmogrifier.sources.transformer.datetime", mocked_datetime):
+        assert source_transformer.get_run_data(source_input_file, run_id) == {
+            "source": "libguides",
+            "run_date": "2024-06-03",
+            "run_type": "full",
+            "run_id": run_id,
+            "run_timestamp": "2024-06-03T12:34:56+00:00",
+        }
 
 
 def test_transformer_get_run_data_with_explicit_run_timestamp(
@@ -167,11 +170,14 @@ def test_transformer_get_run_data_with_explicit_run_timestamp(
     }
 
 
-def test_transformer_get_run_data_mints_timestamp_from_run_date(
+def test_transformer_get_run_data_mints_current_utc_timestamp(
     source_transformer, source_input_file, run_id
 ):
-    result = source_transformer.get_run_data(source_input_file, run_id)
-    assert result["run_timestamp"] == "2024-06-03T00:00:00"
+    mocked_datetime = mock.MagicMock()
+    mocked_datetime.now.return_value.isoformat.return_value = "2024-06-03T12:34:56+00:00"
+    with mock.patch("transmogrifier.sources.transformer.datetime", mocked_datetime):
+        result = source_transformer.get_run_data(source_input_file, run_id)
+    assert result["run_timestamp"] == "2024-06-03T12:34:56+00:00"
 
 
 def test_transformer_get_run_data_no_source_file_raise_error(
@@ -295,7 +301,7 @@ def test_transformer_load_without_run_timestamp_parameter(
         "run_date": "2024-06-03",
         "run_type": "full",
         "run_id": run_id,
-        "run_timestamp": "2024-06-03T00:00:00",
+        "run_timestamp": "2024-06-03T12:34:56+00:00",
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,9 +176,14 @@ def test_transform_run_timestamp_argument_not_passed_and_timestamp_minted(
     caplog, runner, tmp_path
 ):
     caplog.set_level("INFO")
-    with mock.patch(
-        "transmogrifier.sources.transformer.Transformer.write_to_parquet_dataset"
-    ) as mocked_transform_and_write:
+    mocked_datetime = mock.MagicMock()
+    mocked_datetime.now.return_value.isoformat.return_value = "2024-06-03T12:34:56+00:00"
+    with (
+        mock.patch(
+            "transmogrifier.sources.transformer.Transformer.write_to_parquet_dataset"
+        ) as mocked_transform_and_write,
+        mock.patch("transmogrifier.sources.transformer.datetime", mocked_datetime),
+    ):
         mocked_transform_and_write.side_effect = Exception("stopping transformation")
         runner.invoke(
             main,
@@ -192,8 +197,10 @@ def test_transform_run_timestamp_argument_not_passed_and_timestamp_minted(
                 f"{tmp_path}/dataset",
             ],
         )
-    assert "explicit run_id not passed, minting new UUID" in caplog.text
-    assert "run_timestamp set: '2024-06-03T00:00:00'" in caplog.text
+    assert (
+        "explicit run_timestamp not passed, minting current UTC timestamp" in caplog.text
+    )
+    assert "run_timestamp set: '2024-06-03T12:34:56+00:00'" in caplog.text
 
 
 def test_transform_no_memory_fault_for_threaded_bs4_parsing(monkeypatch, tmp_path):

--- a/transmogrifier/sources/json/libguides.py
+++ b/transmogrifier/sources/json/libguides.py
@@ -407,11 +407,15 @@ class LibGuides(JSONTransformer):
     def get_fulltext(self, source_record: dict) -> str | None:
         """Extract meaningful full-text from full Libguide HTML.
 
-        Note: this does not currently capture sidebar content, where things like the guide
+        This does not currently capture sidebar content, where things like the guide
         creator or staff profile is populated.  This is a consideration for future work.
+
+        This method also extracts text from "keywords" metadata tags (repeatable) and
+        adds to the fulltext saved for the record.
         """
         html_soup = self.parse_html(source_record["html_base64"])
 
+        # capture fulltext from guide content
         texts = set()
         selectors = [
             ("div", {"class": "s-lib-header"}),
@@ -421,6 +425,19 @@ class LibGuides(JSONTransformer):
         for element, attrs in selectors:
             if target := html_soup.find(element, attrs=attrs):
                 texts.add(target.get_text(separator=" ", strip=True))
+
+        # capture fulltext from any "keywords" metadata elements
+        for meta in html_soup.find_all("meta"):
+            name = meta.get("name")
+
+            if not name or name.strip().lower() != "keywords":
+                continue
+
+            content = meta.get("content")
+            if not content or not content.strip():
+                continue
+
+            texts.add(content)
 
         return "\n".join(texts)
 

--- a/transmogrifier/sources/transformer.py
+++ b/transmogrifier/sources/transformer.py
@@ -10,7 +10,7 @@ import os
 import re
 import uuid
 from abc import ABC, abstractmethod
-from datetime import date, datetime
+from datetime import UTC, datetime
 from importlib import import_module
 from typing import TYPE_CHECKING, final
 
@@ -313,13 +313,12 @@ class Transformer(ABC):
         logger.info(message)
         run_data["run_id"] = run_id
 
-        # if run_timestamp is not provided, mint one from run_date
+        # if run_timestamp is not provided, mint one from the current UTC time
         if not run_timestamp:
-            logger.info("explicit run_id not passed, minting new UUID")
-            run_timestamp = datetime.combine(
-                date.fromisoformat(run_data["run_date"]),
-                datetime.min.time(),
-            ).isoformat()
+            logger.info(
+                "explicit run_timestamp not passed, minting current UTC timestamp"
+            )
+            run_timestamp = datetime.now(UTC).isoformat()
         message = f"run_timestamp set: '{run_timestamp}'"
         logger.info(message)
         run_data["run_timestamp"] = run_timestamp


### PR DESCRIPTION
### Purpose and background context

See this decision log for more information: https://mitlibraries.atlassian.net/wiki/spaces/D/pages/5321162767/How+to+empower+LibGuide+creators+to+improve+guide+discoverability.

This PR captures `<meta name="keyword" content="..."/>` tags in the libguides HTML `<head>` section when guide creators add custom metadata tags, and maps them to the `fulltext` field in the TIMDEX record.  This improves discoverability without changing the structured data of the TIMDEX record.

Additionally -- purely for development convenience -- a UTC timestamp is minted for local Transmog runs to align with timestamps we see from real deployed runs.

### How can a reviewer manually see the effects of these changes?

See the new test `test_libguides_record_get_fulltext_includes_keywords_metadata` which demonstrates that these HTML `<meta>` tags are getting added to the final record's `fulltext` field.

Alternatively,

1- login to Dev1 AWS console

2- Navigate to new Opensearch serverless (AOSS) collection [timdex-aoss-search-dev](https://us-east-1.console.aws.amazon.com/aos/home?region=us-east-1#opensearch/collections/timdex-aoss-search-dev)

3- Navigate to dashboard via "OpenSearch Dashboards URL" link

4- Run the following query which formerly returned zero results:

```
GET libguides/_search
{
  "_source": ["title", "source_link"],
  "query": {
    "match_phrase": {
      "fulltext": "ISO 9001"
    }
  }
}
```

courtsey of this new `keywords` metadata:

<img width="632" height="136" alt="Screenshot 2026-04-17 at 9 16 35 AM" src="https://github.com/user-attachments/assets/9081d2f1-eb09-42ec-9516-aec7ec78ab89" />

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/USE-470

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.
